### PR TITLE
 avoid unnecessary calls when files are not downloadable on iis

### DIFF
--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 
@@ -453,6 +454,13 @@ namespace LetsEncrypt.ACME.Simple
                 IP = HTTPIP;
             }
             return IP;
+        }
+
+        public override void CheckIfDownloadable(Uri uri)
+        {
+            WebClient wc = new WebClient();
+            wc.DownloadData(uri);
+            base.CheckIfDownloadable(uri);
         }
     }
 }

--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -458,8 +458,10 @@ namespace LetsEncrypt.ACME.Simple
 
         public override void CheckIfDownloadable(Uri uri)
         {
-            WebClient wc = new WebClient();
-            wc.DownloadData(uri);
+            using (WebClient wc = new WebClient())
+            {
+                wc.DownloadData(uri);
+            }
             base.CheckIfDownloadable(uri);
         }
     }

--- a/letsencrypt-win-simple/Plugin/Plugin.cs
+++ b/letsencrypt-win-simple/Plugin/Plugin.cs
@@ -109,5 +109,13 @@ namespace LetsEncrypt.ACME.Simple
         public virtual void DeleteAuthorization(string answerPath, string token, string webRootPath, string filePath)
         {
         }
+
+        /// <summary>
+        /// should check, if Uri is avaiable or not before requesting a certificate
+        /// </summary>
+        /// <param name="uri"></param>
+        public virtual void CheckIfDownloadable(System.Uri uri)
+        {
+        }
     }
 }

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -1226,6 +1226,9 @@ namespace LetsEncrypt.ACME.Simple
 
                 try
                 {
+                    Log.Information("Checking if Url is avaiable...");
+                    target.Plugin.CheckIfDownloadable(answerUri);
+
                     Log.Information("Submitting answer");
                     authzState.Challenges = new AuthorizeChallenge[] { challenge };
                     _client.SubmitChallengeAnswer(authzState, AcmeProtocol.CHALLENGE_TYPE_HTTP, true);


### PR DESCRIPTION
I discovered that on iis requesting a certificate fails when ASP.Net Core is involved.
To avoid unnecessary calls and prevent getting "blacklistenend" by letsencrypt I suppose to check wheter it is possible to reach the files under the .well-known folder. 