### PR TITLE
Use 24 hour time format per default

### DIFF
--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -25,7 +25,7 @@ namespace PKISharp.WACS.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("yyyy/M/d h:mm:ss tt")]
+        [global::System.Configuration.DefaultSettingValueAttribute("yyyy/M/d H:mm:ss tt")]
         public string FileDateFormat {
             get {
                 return ((string)(this["FileDateFormat"]));

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="FileDateFormat" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">yyyy/M/d h:mm:ss tt</Value>
+      <Value Profile="(Default)">yyyy/M/d H:mm:ss tt</Value>
     </Setting>
     <Setting Name="PFXPassword" Type="System.String" Scope="Application">
       <Value Profile="(Default)" />

--- a/letsencrypt-win-simple/settings_default.config
+++ b/letsencrypt-win-simple/settings_default.config
@@ -1,6 +1,6 @@
 ﻿<PKISharp.WACS.Properties.Settings>
   <setting name="FileDateFormat" serializeAs="String">
-    <value>yyyy/M/d h:mm:ss tt</value>
+    <value>yyyy/M/d H:mm:ss tt</value>
   </setting>
   <setting name="PFXPassword" serializeAs="String">
     <value />


### PR DESCRIPTION
I think it makes more sense to use the 24 hour time format instead of the 12 hour time format per default.