### PR TITLE
#804, separate IIS web and FTP site IDs in the renewal target

### DIFF
--- a/letsencrypt-win-simple/Clients/IISClient.cs
+++ b/letsencrypt-win-simple/Clients/IISClient.cs
@@ -625,7 +625,7 @@ namespace PKISharp.WACS.Clients
 
                 var currentThumbprint = sslElement.GetAttributeValue("serverCertHash").ToString();
                 var update = false;
-                if (ftpSite.Id == target.InstallationSiteId)
+                if (ftpSite.Id == target.FtpSiteId)
                 {
                     if (string.Equals(currentThumbprint, newThumbprint, StringComparison.CurrentCultureIgnoreCase))
                     {

--- a/letsencrypt-win-simple/Plugins/InstallationPlugins/IISFTPInstaller.cs
+++ b/letsencrypt-win-simple/Plugins/InstallationPlugins/IISFTPInstaller.cs
@@ -24,7 +24,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 _iisClient.FtpSites,
                 x => new Choice<long>(x.Id) { Description = x.Name, Command = x.Id.ToString() },
                 false);
-                renewal.Binding.InstallationSiteId = chosen;
+                renewal.Binding.FtpSiteId = chosen;
         }
 
         public override void Default(ScheduledRenewal renewal, IOptionsService optionsService)
@@ -41,7 +41,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
             if (siteId != null)
             {
                 var site = _iisClient.GetFtpSite(siteId.Value); // Throws exception when not found
-                renewal.Binding.InstallationSiteId = site.Id;
+                renewal.Binding.FtpSiteId = site.Id;
             }
             else
             {

--- a/letsencrypt-win-simple/Plugins/InstallationPlugins/IISFtpInstaller.cs
+++ b/letsencrypt-win-simple/Plugins/InstallationPlugins/IISFtpInstaller.cs
@@ -24,7 +24,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 _iisClient.FtpSites,
                 x => new Choice<long>(x.Id) { Description = x.Name, Command = x.Id.ToString() },
                 false);
-                renewal.Binding.InstallationSiteId = chosen;
+                renewal.Binding.FtpSiteId = chosen;
         }
 
         public override void Default(ScheduledRenewal renewal, IOptionsService optionsService)
@@ -41,7 +41,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
             if (siteId != null)
             {
                 var site = _iisClient.GetFtpSite(siteId.Value); // Throws exception when not found
-                renewal.Binding.InstallationSiteId = site.Id;
+                renewal.Binding.FtpSiteId = site.Id;
             }
             else
             {

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
@@ -76,6 +76,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
                 TargetSiteId = -1,
                 ValidationSiteId = null, 
                 InstallationSiteId = null,
+                FtpSiteId = null,
                 AlternativeNames = siteList.SelectMany(x => x.AlternativeNames).Distinct().ToList()
             };
             return totalTarget;
@@ -112,6 +113,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
                 x.ValidationPort = scheduled.ValidationPort;
                 x.ValidationSiteId = scheduled.ValidationSiteId;
                 x.InstallationSiteId = scheduled.InstallationSiteId;
+                x.FtpSiteId = scheduled.FtpSiteId;
                 x.ExcludeBindings = scheduled.ExcludeBindings;
                 x.ValidationPluginName = scheduled.ValidationPluginName;
                 x.DnsAzureOptions = scheduled.DnsAzureOptions;

--- a/letsencrypt-win-simple/Target.cs
+++ b/letsencrypt-win-simple/Target.cs
@@ -62,6 +62,11 @@ namespace PKISharp.WACS
         public long? InstallationSiteId { get; set; }
 
         /// <summary>
+        /// FTP Site used to install newly detected bindings
+        /// </summary>
+        public long? FtpSiteId { get; set; }
+
+        /// <summary>
         /// Port to create new SSL bindings on
         /// </summary>
         public int? SSLPort { get; set; }


### PR DESCRIPTION
Manually tested renewing with a renewal generated from an old version. Tested creating a renewal with the installationsiteid and ftpsiteid specified. Tested a renewal with those set