### PR TITLE
Add Option to manually set Common Name

### DIFF
--- a/letsencrypt-win-simple/Configuration/Options.cs
+++ b/letsencrypt-win-simple/Configuration/Options.cs
@@ -38,6 +38,9 @@ namespace PKISharp.WACS
         [Option(HelpText = "[--plugin iissite|iissites|iisbinding] Specify identifier of the site that the plugin should create the target from. For the iissites plugin this may be a comma separated list.")]
         public string SiteId { get; set; }
 
+        [Option(HelpText = "[--plugin iissite|iissites|manual] Specify the common name of the certificate that should be requested for the target.")]
+        public string CommonName { get; set; }
+
         [Option(HelpText = "[--plugin iissite|iissites] Exclude bindings from being included in the certificate. This may be a comma separated list.")]
         public string ExcludeBindings { get; set; }
 

--- a/letsencrypt-win-simple/Extensions/TargetExtensions.cs
+++ b/letsencrypt-win-simple/Extensions/TargetExtensions.cs
@@ -16,8 +16,9 @@ namespace PKISharp.WACS.Extensions
 
         public static void AskForCommonNameChoice(this Target target, IInputService inputService)
         {
+            if (target.AlternativeNames.Count < 2) return;
             var sanChoices = target.AlternativeNames.OrderBy(x => x).Select(san => Choice.Create<string>(san)).ToList();
-            target.CommonName = inputService.ChooseFromList("Choose a domain name to be the certificate's common name or press enter", sanChoices, false);
+            target.CommonName = inputService.ChooseFromList("Choose a domain name to be the certificate's common name", sanChoices, false);
         }
     }
 }

--- a/letsencrypt-win-simple/Extensions/TargetExtensions.cs
+++ b/letsencrypt-win-simple/Extensions/TargetExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using PKISharp.WACS.Services;
+
+namespace PKISharp.WACS.Extensions
+{
+    public static class TargetExtensions
+    {
+        public static bool IsCommonNameValid(this Target target, ILogService failureLogService = null)
+        {
+            var cn = target.CommonName;
+            var isValid = cn == null || target.AlternativeNames.Contains(cn, StringComparer.InvariantCultureIgnoreCase);
+            if (failureLogService != null && !isValid) failureLogService.Error($"The supplied common name '{target.CommonName}' is none of this target's alternative names.");
+            return isValid;
+        }
+
+        public static void AskForCommonNameChoice(this Target target, IInputService inputService)
+        {
+            var sanChoices = target.AlternativeNames.OrderBy(x => x).Select(san => Choice.Create<string>(san)).ToList();
+            target.CommonName = inputService.ChooseFromList("Choose a domain name to be the certificate's common name or press enter", sanChoices, false);
+        }
+    }
+}

--- a/letsencrypt-win-simple/MainMenu.cs
+++ b/letsencrypt-win-simple/MainMenu.cs
@@ -59,6 +59,7 @@ namespace PKISharp.WACS
                         var resolver = scope.Resolve<UnattendedResolver>();
                         _input.Show("Name", target.Binding.Host, true);
                         _input.Show("AlternativeNames", string.Join(", ", target.Binding.AlternativeNames));
+                        _input.Show("CommonName", target.Binding.CommonName);
                         _input.Show("ExcludeBindings", target.Binding.ExcludeBindings);
                         _input.Show("Target plugin", resolver.GetTargetPlugin(scope).Description);
                         _input.Show("Validation plugin", resolver.GetValidationPlugin(scope).Description);

--- a/letsencrypt-win-simple/MainMenu.cs
+++ b/letsencrypt-win-simple/MainMenu.cs
@@ -59,7 +59,7 @@ namespace PKISharp.WACS
                         var resolver = scope.Resolve<UnattendedResolver>();
                         _input.Show("Name", target.Binding.Host, true);
                         _input.Show("AlternativeNames", string.Join(", ", target.Binding.AlternativeNames));
-                        _input.Show("CommonName", target.Binding.CommonName);
+                        _input.Show("CommonName", target.Binding.CommonName ?? "<not set>");
                         _input.Show("ExcludeBindings", target.Binding.ExcludeBindings);
                         _input.Show("Target plugin", resolver.GetTargetPlugin(scope).Description);
                         _input.Show("Validation plugin", resolver.GetValidationPlugin(scope).Description);

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/IISSite.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/IISSite.cs
@@ -43,6 +43,8 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
                 if (found != null)
                 {
                     found.ExcludeBindings = optionsService.Options.ExcludeBindings;
+                    found.CommonName = optionsService.Options.CommonName;
+                    if (!found.IsCommonNameValid(_log)) return null;
                     return found;
                 }
                 else
@@ -68,6 +70,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
                 // Exclude bindings 
                 inputService.WritePagedList(chosen.AlternativeNames.Select(x => Choice.Create(x, "")));
                 chosen.ExcludeBindings = inputService.RequestString("Press enter to include all listed hosts, or type a comma-separated lists of exclusions");
+                if (runLevel >= RunLevel.Advanced) chosen.AskForCommonNameChoice(inputService);
                 return chosen;
             }
             return null;

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
@@ -90,6 +90,25 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             var totalTarget = GetCombinedTarget(targets, sanInput);
             inputService.WritePagedList(totalTarget.AlternativeNames.Select(x => Choice.Create(x, "")));
             totalTarget.ExcludeBindings = inputService.RequestString("Press enter to include all listed hosts, or type a comma-separated lists of exclusions");
+
+            var sanIdx = 1;
+            var sans = totalTarget.AlternativeNames.OrderBy(x => x).ToDictionary(x => sanIdx++);
+            inputService.WritePagedList(sans.Select(x => Choice.Create(x.Value, x.Key.ToString())));
+            var commonNameInput = inputService.RequestString("Enter a domain name index if you want to set the certificate's common name or press enter");
+            int commonNameIdx;
+            if (Int32.TryParse(commonNameInput, out commonNameIdx))
+            {
+                if (!sans.ContainsKey(commonNameIdx))
+                {
+                    _log.Error("The certificate's common name has to be one of the hosts it is requested for.");
+                    return null;
+                }
+                totalTarget.CommonName = sans[commonNameIdx];
+            } else
+            {
+                _log.Error("Your input was not a number.");
+                return null;
+            }
             return totalTarget;
         }
 

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
@@ -5,6 +5,7 @@ using PKISharp.WACS.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using PKISharp.WACS.Extensions;
 
 namespace PKISharp.WACS.Plugins.TargetPlugins
 {
@@ -29,13 +30,8 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             var rawSiteId = optionsService.TryGetRequiredOption(nameof(optionsService.Options.SiteId), optionsService.Options.SiteId);
             var totalTarget = GetCombinedTarget(GetSites(false, false), rawSiteId);
             totalTarget.ExcludeBindings = optionsService.Options.ExcludeBindings;
-            var cn = optionsService.Options.CommonName;
-            if (cn != null && !totalTarget.AlternativeNames.Contains(cn, StringComparer.InvariantCultureIgnoreCase))
-            {
-                _log.Error($"The supplied common name '{cn}' is not one of this target's alternative names.");
-                return null;
-            }
-            totalTarget.CommonName = cn;
+            totalTarget.CommonName = optionsService.Options.CommonName;
+            if (!totalTarget.IsCommonNameValid(_log)) return null;
             return totalTarget;
         }
 
@@ -97,11 +93,7 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             var totalTarget = GetCombinedTarget(targets, sanInput);
             inputService.WritePagedList(totalTarget.AlternativeNames.Select(x => Choice.Create(x, "")));
             totalTarget.ExcludeBindings = inputService.RequestString("Press enter to include all listed hosts, or type a comma-separated lists of exclusions");
-            if (runLevel >= RunLevel.Advanced)
-            {
-                var sanChoices = totalTarget.AlternativeNames.OrderBy(x => x).Select(san => Choice.Create<string>(san)).ToList();
-                totalTarget.CommonName = inputService.ChooseFromList("Choose a domain name to be the certificate's common name or press enter", sanChoices, false);
-            }
+            if (runLevel >= RunLevel.Advanced) totalTarget.AskForCommonNameChoice(inputService);
             return totalTarget;
         }
 

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
@@ -29,6 +29,13 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             var rawSiteId = optionsService.TryGetRequiredOption(nameof(optionsService.Options.SiteId), optionsService.Options.SiteId);
             var totalTarget = GetCombinedTarget(GetSites(false, false), rawSiteId);
             totalTarget.ExcludeBindings = optionsService.Options.ExcludeBindings;
+            var cn = optionsService.Options.CommonName;
+            if (cn != null && !totalTarget.AlternativeNames.Contains(cn, StringComparer.InvariantCultureIgnoreCase))
+            {
+                _log.Error($"The supplied common name '{cn}' is not one of this target's alternative names.");
+                return null;
+            }
+            totalTarget.CommonName = cn;
             return totalTarget;
         }
 

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/IISSites.cs
@@ -90,24 +90,10 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
             var totalTarget = GetCombinedTarget(targets, sanInput);
             inputService.WritePagedList(totalTarget.AlternativeNames.Select(x => Choice.Create(x, "")));
             totalTarget.ExcludeBindings = inputService.RequestString("Press enter to include all listed hosts, or type a comma-separated lists of exclusions");
-
-            var sanIdx = 1;
-            var sans = totalTarget.AlternativeNames.OrderBy(x => x).ToDictionary(x => sanIdx++);
-            inputService.WritePagedList(sans.Select(x => Choice.Create(x.Value, x.Key.ToString())));
-            var commonNameInput = inputService.RequestString("Enter a domain name index if you want to set the certificate's common name or press enter");
-            int commonNameIdx;
-            if (Int32.TryParse(commonNameInput, out commonNameIdx))
+            if (runLevel >= RunLevel.Advanced)
             {
-                if (!sans.ContainsKey(commonNameIdx))
-                {
-                    _log.Error("The certificate's common name has to be one of the hosts it is requested for.");
-                    return null;
-                }
-                totalTarget.CommonName = sans[commonNameIdx];
-            } else
-            {
-                _log.Error("Your input was not a number.");
-                return null;
+                var sanChoices = totalTarget.AlternativeNames.OrderBy(x => x).Select(san => Choice.Create<string>(san)).ToList();
+                totalTarget.CommonName = inputService.ChooseFromList("Choose a domain name to be the certificate's common name or press enter", sanChoices, false);
             }
             return totalTarget;
         }

--- a/letsencrypt-win-simple/Plugins/TargetPlugins/Manual.cs
+++ b/letsencrypt-win-simple/Plugins/TargetPlugins/Manual.cs
@@ -3,6 +3,7 @@ using PKISharp.WACS.Plugins.Interfaces;
 using PKISharp.WACS.Services;
 using System.Collections.Generic;
 using System.Linq;
+using PKISharp.WACS.Extensions;
 
 namespace PKISharp.WACS.Plugins.TargetPlugins
 {
@@ -23,13 +24,18 @@ namespace PKISharp.WACS.Plugins.TargetPlugins
         Target ITargetPlugin.Default(IOptionsService optionsService)
         {
             var input = optionsService.TryGetRequiredOption(nameof(optionsService.Options.ManualHost), optionsService.Options.ManualHost);
-            return Create(input);
+            var target = Create(input);
+            target.CommonName = optionsService.Options.CommonName;
+            if (!target.IsCommonNameValid(_log)) return null;
+            return target;
         }
 
         Target ITargetPlugin.Aquire(IOptionsService optionsService, IInputService inputService, RunLevel runLevel)
         {
-           var input = inputService.RequestString("Enter comma-separated list of host names, starting with the primary one");
-           return Create(input);
+            var input = inputService.RequestString("Enter comma-separated list of host names, starting with the primary one");
+            var target = Create(input);
+            if (runLevel >= RunLevel.Advanced) target.AskForCommonNameChoice(inputService);
+            return target;
         }
 
         Target Create(string input)

--- a/letsencrypt-win-simple/Services/CertificateService.cs
+++ b/letsencrypt-win-simple/Services/CertificateService.cs
@@ -331,7 +331,8 @@ namespace PKISharp.WACS.Services
         {
             if (commonName != null && !identifiers.Contains(commonName, StringComparer.InvariantCultureIgnoreCase))
             {
-                throw new ArgumentException($"{nameof(identifiers)} has to contain {nameof(commonName)} '{commonName}'.");
+                _log.Warning($"{nameof(commonName)} '{commonName}' provided for CSR generation is invalid. It has to be part of the {nameof(identifiers)}.");
+                commonName = null;
             }
             var csr = cp.GenerateCsr(new CsrParams
             {

--- a/letsencrypt-win-simple/Services/CertificateService.cs
+++ b/letsencrypt-win-simple/Services/CertificateService.cs
@@ -120,7 +120,7 @@ namespace PKISharp.WACS.Services
                 // Generate the private key and CSR
                 var rsaPkp = GetRsaKeyParameters();
                 var rsaKeys = cp.GeneratePrivateKey(rsaPkp);
-                var csr = GetCsr(cp, identifiers, rsaKeys);
+                var csr = GetCsr(cp, identifiers, rsaKeys, binding.CommonName);
                 byte[] derRaw;
                 using (var bs = new MemoryStream())
                 {
@@ -327,13 +327,17 @@ namespace PKISharp.WACS.Services
         /// <param name="identifiers"></param>
         /// <param name="rsaPk"></param>
         /// <returns></returns>
-        private Csr GetCsr(CertificateProvider cp, List<string> identifiers, PrivateKey rsaPk)
+        private Csr GetCsr(CertificateProvider cp, List<string> identifiers, PrivateKey rsaPk, string commonName = null)
         {
+            if (commonName != null && !identifiers.Contains(commonName, StringComparer.InvariantCultureIgnoreCase))
+            {
+                throw new ArgumentException($"{nameof(identifiers)} has to contain {nameof(commonName)} '{commonName}'.");
+            }
             var csr = cp.GenerateCsr(new CsrParams
             {
                 Details = new CsrDetails()
                 {
-                    CommonName = identifiers.FirstOrDefault(),
+                    CommonName = commonName ?? identifiers.FirstOrDefault(),
                     AlternativeNames = identifiers
                 }
             }, rsaPk, Crt.MessageDigest.SHA256);

--- a/letsencrypt-win-simple/Target.cs
+++ b/letsencrypt-win-simple/Target.cs
@@ -24,6 +24,12 @@ namespace PKISharp.WACS
         public bool? HostIsDns { get; set; }
 
         /// <summary>
+        /// The common name of the certificate. Has to be one of
+        /// the alternative names.
+        /// </summary>
+        public string CommonName { get; set; }
+
+        /// <summary>
         /// Hide target from the user in interactive mode, i.e.
         /// because some filter has been applied (--hidehttps).
         /// </summary>


### PR DESCRIPTION
When requesting a SAN certificate it might be quite useful to set the certificate's common name manually. Imagine company X hosts shop A's and shop B's website plus it's own site using a single IP setup without SNI (i.e. using IIS 7.5). Accordingly the certificate should have a.com, b.com and x.com as SANs. Now for X it would be quite preferable to have x.com as a common name instead of a.com. If we need to change more than this please let me know, I'm happy to help here.