### PR TITLE
CI with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,19 @@
+image: Visual Studio 2017
 version: 1.0.{build}
-install:
-- git clone https://github.com/ebekker/letsencrypt-win.git
-#- nuget restore letsencrypt-win\letsencrypt-win.sln
-- nuget restore letsencrypt-win-simple.sln
-- cp -R packages letsencrypt-win
+
+configuration: Release
+
+before_build:
+  - nuget restore
+
 build:
-  project: letsencrypt-win-simple.sln
-  verbosity: minimal
+  project: win-acme.sln
+  verbosity: normal
+
 artifacts:
-- path: letsencrypt-win-simple\bin\debug
-  name: letsencrypt-win-simple
-  type: zip
+  - path: letsencrypt-win-simple\bin\$(CONFIGURATION)
+    name: win-acme-$(CONFIGURATION)-$(APPVEYOR_BUILD_NUMBER)
+    type: zip
+
+cache:
+  - packages -> **\packages.config


### PR DESCRIPTION
Merging this updates the `appveyor.yml` to get CI working (again). I think having CI is a good idea 

* to avoid things like in #838
* to have a reproducible build process
* because it's free
* because it enables things like this: [![Build status](https://ci.appveyor.com/api/projects/status/enu9jxh4mnh73baq?svg=true)](https://ci.appveyor.com/project/georg-jung/win-acme)
* because it can be extended to run tests, do deployments, ...

To get this done one of PKISharp has to create a free appveyor account and set the project up, which is very simple, as all configuration lies in the `appveyor.yml` file. I'd be happy to help out if needed.