### PR TITLE
Remove SQLite + EntityFramework

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -4,8 +4,6 @@
     <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
       <section name="PKISharp.WACS.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     </sectionGroup>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <appSettings>
     <add key="ClientSettingsProvider.ServiceUri" value="" />
@@ -84,21 +82,4 @@
       </providers>
     </roleManager>
   </system.web>
-  <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
-      <parameters>
-        <parameter value="v13.0" />
-      </parameters>
-    </defaultConnectionFactory>
-    <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
-    </providers>
-  </entityFramework>
-  <system.data>
-    <DbProviderFactories>
-      <remove invariant="System.Data.SQLite.EF6" />
-      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
-    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
-  </system.data>
 </configuration>

--- a/letsencrypt-win-simple/packages.config
+++ b/letsencrypt-win-simple/packages.config
@@ -11,7 +11,6 @@
   <package id="BouncyCastle" version="1.8.1" targetFramework="net461" />
   <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net461" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net461" developmentDependency="true" />
-  <package id="EntityFramework" version="6.0.0" targetFramework="net461" />
   <package id="Fody" version="2.2.1.0" targetFramework="net461" developmentDependency="true" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="ManagedOpenSsl32" version="0.6.1.3" targetFramework="net461" />
@@ -39,10 +38,6 @@
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
   <package id="System.Console" version="4.3.0" targetFramework="net461" />
-  <package id="System.Data.SQLite" version="1.0.107.0" targetFramework="net461" />
-  <package id="System.Data.SQLite.Core" version="1.0.107.0" targetFramework="net461" />
-  <package id="System.Data.SQLite.EF6" version="1.0.107.0" targetFramework="net461" />
-  <package id="System.Data.SQLite.Linq" version="1.0.107.0" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.TraceSource" version="4.3.0" targetFramework="net461" />

--- a/letsencrypt-win-simple/win-acme.csproj
+++ b/letsencrypt-win-simple/win-acme.csproj
@@ -143,12 +143,6 @@
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-    </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
@@ -223,15 +217,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.107.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.107.0\lib\net46\System.Data.SQLite.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Data.SQLite.EF6, Version=1.0.107.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.107.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Data.SQLite.Linq, Version=1.0.107.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.107.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
-    </Reference>
     <Reference Include="System.Diagnostics.TraceSource">
       <HintPath>..\packages\System.Diagnostics.TraceSource.4.3.0\lib\net46\System.Diagnostics.TraceSource.dll</HintPath>
       <Private>True</Private>
@@ -485,12 +470,10 @@
     <Error Condition="!Exists('..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets'))" />
-    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.107.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.107.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
   <Import Project="..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Import Project="..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" />
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.107.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.107.0\build\net46\System.Data.SQLite.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
SQLite and EF currently are a dependency of the project. Even though I did not find any uses of them - maybe I'm blind for it. Maybe they are used implicitly somewhere, which I didn't notice, so we should really check this.

When removing them, I'm still able to compile the project and I still get certificates for IISSites with http-01 self-hosting without any error. Looking at the history makes me think that the dependencies where introduced in 8a33c662fa6368c2938c21fcfaa357322d8de3b0, but I can not find any need for them in this commit or it's message. Removing them would have some advantages:

1. reduce .exe file size - it is more than 1mb smaller afterwards
2. unused dependencies are bad for many reasons including security
3. the content of the build output dir (i.e. `Release`) is exactly what `build.ps1` manually copies file-by-file, so we could possibly easily replace the custom build script with CI, see #842 

Notice that this PR's build is [failing in AppVeyor](https://ci.appveyor.com/project/georg-jung/win-acme/build/1.0.17) because the CI process just works when merging #842 first.