### PR TITLE
fix missing line break after 'Press enter to continue'

### DIFF
--- a/letsencrypt-win-simple/Services/InputService.cs
+++ b/letsencrypt-win-simple/Services/InputService.cs
@@ -59,6 +59,7 @@ namespace PKISharp.WACS.Services
                     switch (response.Key)
                     {
                         case ConsoleKey.Enter:
+                            Console.WriteLine();
                             return true;
                         case ConsoleKey.Escape:
                             Console.WriteLine();


### PR DESCRIPTION
When there is a long list in the console output, it is sliced in parts, separated by `Press enter to continue...`. After pressing enter, the next item is shown on the same line as `Press enter to continue...`. I think having a line break in between would be better.