### PR TITLE
Fix some logic errors in the DNS script validation

### DIFF
--- a/src/main/Plugins/ValidationPlugins/Dns/Script/ScriptArgumentsProvider.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/Script/ScriptArgumentsProvider.cs
@@ -31,7 +31,8 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
 
         public override bool Active(ScriptArguments current)
         {
-            return !string.IsNullOrEmpty(current.DnsCreateScript) ||
+            return !string.IsNullOrEmpty(current.DnsScript) || 
+                !string.IsNullOrEmpty(current.DnsCreateScript) ||
                 !string.IsNullOrEmpty(current.DnsDeleteScript) ||
                 !string.IsNullOrEmpty(current.DnsDeleteScriptArguments) ||
                 !string.IsNullOrEmpty(current.DnsCreateScriptArguments);

--- a/src/main/Plugins/ValidationPlugins/Dns/Script/ScriptOptionsFactory.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/Script/ScriptOptionsFactory.cs
@@ -63,7 +63,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             {
                 if (!ret.Script.ValidFile(_log))
                 {
-                    throw new ArgumentException(nameof(args.DnsCreateScript));
+                    throw new ArgumentException(nameof(args.DnsScript));
                 }
             }
             else
@@ -101,14 +101,12 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             }
             if (!string.IsNullOrWhiteSpace(commonInput))
             {
-                options.Script = createInput;
-                if (!string.IsNullOrWhiteSpace(createInput) &&
-                    !string.Equals(createInput, commonInput, StringComparison.InvariantCultureIgnoreCase))
+                options.Script = commonInput;
+                if (!string.IsNullOrWhiteSpace(createInput))
                 {
                     _log.Warning($"Ignoring --dnscreatescript because --dnsscript was provided");
                 }
-                if (!string.IsNullOrWhiteSpace(deleteInput) &&
-                    !string.Equals(deleteInput, commonInput, StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(deleteInput))
                 {
                     _log.Warning("Ignoring --dnsdeletescript because --dnsscript was provided");
                 }

--- a/src/main/Plugins/ValidationPlugins/Dns/Script/ScriptOptionsFactory.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/Script/ScriptOptionsFactory.cs
@@ -94,6 +94,19 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         /// <param name="deleteInput"></param>
         private void ProcessScripts(ScriptOptions options, string commonInput, string createInput, string deleteInput)
         {
+            if (!string.IsNullOrWhiteSpace(commonInput))
+            {
+                if(!string.IsNullOrWhiteSpace(createInput))
+                {
+                    _log.Warning($"Ignoring --dnscreatescript because --dnsscript was provided");
+                }
+                if (!string.IsNullOrWhiteSpace(deleteInput))
+                {
+                    _log.Warning("Ignoring --dnsdeletescript because --dnsscript was provided");
+                }
+            }
+                
+            
             if (string.IsNullOrWhiteSpace(commonInput) && 
                 string.Equals(createInput, deleteInput, StringComparison.CurrentCultureIgnoreCase))
             {
@@ -102,14 +115,6 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             if (!string.IsNullOrWhiteSpace(commonInput))
             {
                 options.Script = commonInput;
-                if (!string.IsNullOrWhiteSpace(createInput))
-                {
-                    _log.Warning($"Ignoring --dnscreatescript because --dnsscript was provided");
-                }
-                if (!string.IsNullOrWhiteSpace(deleteInput))
-                {
-                    _log.Warning("Ignoring --dnsdeletescript because --dnsscript was provided");
-                }
             }
             else
             {


### PR DESCRIPTION
Fixes Bugs:
1. Wrong validation plugin name in help for DNS script validation.
2. Validation plugin fails when specifying only a a common DNS script for both creating and deleting the DNS record.

Before

```
PS C:\letsencrypt> .\wacs.exe --verbose --target manual --host ..copperleaf.cloud,-test-instance..c
opperleaf.cloud --validationmode dns-01 --validation dnsscript
 --dnsscript C:\\letsencrypt\\dnshandler.ps1 --emailaddres
s devops@copperleaf.com --accepttos --test

 [INFO] A simple Windows ACMEv2 client (WACS)
 [INFO] Software version 2.0.2.198 (RELEASE)
 [INFO] IIS version 8.5
 [INFO] Please report issues at https://github.com/PKISharp/win-acme

 [VERB] Verbose mode logging enabled
 [VERB] Arguments: --verbose --target manual --host 1.com,2.com --validationmode dns-01 --validation dnsscript --dnsscript C:\\letsencrypt\\dnshandler.ps1 --emailaddress devops@copperleaf.com --accepttos --test
 [DBUG] Config folder: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org
 [DBUG] Certificate cache: C:\letsencrypt\certs
 [VERB] Settings SettingsService {ConfigPath="C:\\ProgramData\\win-acme\\acme-staging-v02.api.letsencrypt.org", Certific
atePath="C:\\letsencrypt\\certs", ClientNames=["win-acme", "win-acme"], RenewalDays=55, HostsPerPage=50, ScheduledTaskRa
ndomDelay=00:00:00, ScheduledTaskStartBoundary=09:00:00, ScheduledTaskExecutionTimeLimit=02:00:00}
 [VERB] Sending e-mails False
 [DBUG] Renewal period: 55 days
 [INFO] Running in mode: Unattended, Test
 [INFO] Target generated using plugin Manual: 1.com
 [EROR] Unable to parse path null
 [DBUG] ArgumentException: ArgumentException {Message="DnsCreateScript", ParamName=null, Data=[], InnerException=null, T
argetSite=PKISharp.WACS.Plugins.ValidationPlugins.Dns.ScriptOptions Default(PKISharp.WACS.DomainObjects.Target, PKISharp
.WACS.Services.IArgumentsService), StackTrace="   at PKISharp.WACS.Plugins.ValidationPlugins.Dns.ScriptOptionsFactory.De
fault(Target target, IArgumentsService arguments)\r\n   at PKISharp.WACS.Plugins.Base.Factories.ValidationPluginOptionsF
actory`2.PKISharp.WACS.Plugins.Interfaces.IValidationPluginOptionsFactory.Default(Target target, IArgumentsService argum
ents)\r\n   at PKISharp.WACS.Wacs.CreateNewCertificate(RunLevel runLevel)", HelpLink=null, Source="wacs", HResult=-21470
24809}
 [EROR] ArgumentException: Validation plugin DnsScript aborted or failed

 [--test] Quit? (y/n*)  - yes

```

After building and deploying the fix

```
PS C:\letsencrypt> .\wacs.exe --verbose --target manual --host ..copperleaf.cloud,-test-instance..c
opperleaf.cloud --validationmode dns-01 --validation dnsscript --dnsscript C:\\letsencrypt\\dnshandler.ps1 --emailaddres
s devops@copperleaf.com --accepttos --test

 [INFO] A simple Windows ACMEv2 client (WACS)
 [INFO] Software version 2.0.3.2 (DEBUG)
 [INFO] IIS version 8.5
 [INFO] Please report issues at https://github.com/PKISharp/win-acme

 [VERB] Verbose mode logging enabled
 [VERB] Arguments: --verbose --target manual --host ..copperleaf.cloud -test-instance..copperleaf.c
loud --validationmode dns-01 --validation dnsscript --dnsscript C:\\letsencrypt\\dnshandler.ps1 --emailaddress devops@co
pperleaf.com --accepttos --test
 [DBUG] Config folder: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org
 [DBUG] Certificate cache: C:\letsencrypt\certs
 [VERB] Settings SettingsService {ConfigPath="C:\\ProgramData\\win-acme\\acme-staging-v02.api.letsencrypt.org", Certific
atePath="C:\\letsencrypt\\certs", ClientNames=["win-acme", "win-acme"], RenewalDays=55, HostsPerPage=50, ScheduledTaskRa
ndomDelay=00:00:00, ScheduledTaskStartBoundary=09:00:00, ScheduledTaskExecutionTimeLimit=02:00:00}
 [VERB] Sending e-mails False
 [DBUG] Renewal period: 55 days
 [INFO] Running in mode: Unattended, Test
 [INFO] Target generated using plugin Manual: ..copperleaf.cloud
 [VERB] Checking [Manual] ..copperleaf.cloud
 [DBUG] Loading signer from C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Signer_v2
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/directory
 [DBUG] Send HEAD request to https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce
 [DBUG] Loading account information from C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Registration_v2
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/new-order
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/acme/authz/ddP4f9k9hchQf0xRyLVxVf4ZpjmQHUCDtjpX
_bbunsY
 [INFO] Authorize identifier: ..copperleaf.cloud
 [INFO] Authorizing ..copperleaf.cloud using dns-01 validation (DnsScript)
 [INFO] Script C:\\letsencrypt\\dnshandler.ps1 starting with parameters create ..copperleaf.cloud _acme-cha
llenge...copperleaf.cloud PzS25Eu2pIGDptG_qHdUEI2SeeSTH9yDP9fmiMzf0wE
 [INFO] {
    "ChangeInfo": {
        "Status": "PENDING",
        "Comment": "Create record for letsencrypt cert",
        "SubmittedAt": "2019-02-26T04:53:47.416Z",
        "Id": "/change/C1DZSUEMFGOHG8"
    }
}

 [INFO] Answer should now be available at _acme-challenge...copperleaf.cloud
 [WARN] Preliminary validation failed, found (null) instead of PzS25Eu2pIGDptG_qHdUEI2SeeSTH9yDP9fmiMzf0wE
 [DBUG] Submitting challenge answer
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/challenge/ddP4f9k9hchQf0xRyLVxVf4ZpjmQHUC
DtjpX_bbunsY/254143612
 [DBUG] Refreshing authorization
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/acme/challenge/ddP4f9k9hchQf0xRyLVxVf4ZpjmQHUCD
tjpX_bbunsY/254143612
 [INFO] Authorization result: valid
 [INFO] Script C:\\letsencrypt\\dnshandler.ps1 starting with parameters delete ..copperleaf.cloud _acme-cha
llenge...copperleaf.cloud PzS25Eu2pIGDptG_qHdUEI2SeeSTH9yDP9fmiMzf0wE
 [INFO] {
    "ChangeInfo": {
        "Status": "PENDING",
        "Comment": "Create record for letsencrypt cert",
        "SubmittedAt": "2019-02-26T04:54:11.139Z",
        "Id": "/change/C2GZ0UT9UX92SG"
    }
}

 [DBUG] Certificate store: WebHosting
 [DBUG] RSAKeyBits: 3072
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/finalize/8359492/24367580
 [INFO] Requesting certificate [Manual] ..copperleaf.cloud
 [VERB] Set private key exportable

 [--test] Do you want to install the certificate? (y*/n)  - yes

 [INFO] Installing certificate in the certificate store
 [DBUG] Opened certificate store WebHosting
 [INFO] Adding certificate [Manual] ..copperleaf.cloud 2019/2/25 20:54:11 to store WebHosting
 [VERB] CN=..copperleaf.cloud - CN=Fake LE Intermediate X1 (358CB5AD398F84D5061878698FF2288A7BCA7)
 [VERB] CN=Fake LE Intermediate X1 - CN=Fake LE Root X1 (4EEE7398C1A3DAF91DA16689DB8243927A271B9A) to CA store
 [VERB] CN=Fake LE Root X1 - CN=Fake LE Root X1 (B3F73C419DAC14711F4B97192BF89C7DEA7A7794) to AuthRoot store
 [DBUG] Closing certificate stores
 [INFO] Installing with None...

 [--test] Do you want to automatically renew this certificate? (y*/n)  - yes

 [INFO] Adding Task Scheduler entry with the following settings
 [INFO] - Name win-acme renew (acme-staging-v02.api.letsencrypt.org)
 [INFO] - Path C:\letsencrypt
 [INFO] - Command wacs.exe --renew --baseuri "https://acme-staging-v02.api.letsencrypt.org/"
 [INFO] - Start at 09:00:00
 [INFO] - Time limit 02:00:00
 [DBUG] Creating task to run as system user
 [INFO] Adding renewal for [Manual] ..copperleaf.cloud
 [INFO] Next renewal scheduled at 2019/4/21 21:54:11

 [--test] Quit? (y/n*)  - yes```