### PR TITLE
Updated acme-dns tokens for test; CNAME verification UI tweaks

### DIFF
--- a/src/main.test/Tests/DnsValidationTests/When_resolving_name_servers.cs
+++ b/src/main.test/Tests/DnsValidationTests/When_resolving_name_servers.cs
@@ -21,8 +21,8 @@ namespace PKISharp.WACS.UnitTests.Tests.DnsValidationTests
 
 		[TestMethod]
 		[DataRow("_acme-challenge.logs.hourstrackercloud.com", "Tx1e8X4LF-c615tnacJeuKmzkRmScZzsU-MJHxdDMhU")]
-		[DataRow("_acme-challenge.candell.org", "PVyGjIMLGq9AnlKFvIX1aeSABFVmjbBvpez1_405ByI")]
-		[DataRow("_acme-challenge.candell.org", "RwXi-dahnVtbNwzS9N9iUoC70o2S14ikGc70ofnKjZw")]
+		[DataRow("_acme-challenge.candell.org", "VFQngqEagia0xpVVA80BIkm-moeWbgTyozbzMvu6S4Q")]
+		[DataRow("_acme-challenge.candell.org", "Vsr-Wn0qP11KkBj-R-xBITMQOhOOQbTORl2BXbXfVHs")]
         [DataRow("_acme-challenge.wouter.tinus.online", "DHrsG3LudqI9S0jvitp25tDofK1Jf58J08s3c5rIY3k")]
         public void Should_recursively_follow_cnames(string challengeUri, string expectedToken)
 		{

--- a/src/main/Clients/AcmeDnsClient.cs
+++ b/src/main/Clients/AcmeDnsClient.cs
@@ -77,11 +77,16 @@ namespace PKISharp.WACS.Clients
             else
             {
                 _log.Information($"Existing acme-dns registration for domain {domain} found");
+                _log.Information($"Record: _acme-challenge.{domain}");
+                _log.Information("CNAME: " + oldReg.Fulldomain);
                 while (!VerifyConfiguration(domain, oldReg.Fulldomain))
                 {
                     if (interactive)
                     {
-                        _input.Wait("Please press enter after you've corrected the record.");
+                        if (!_input.Wait("Please press enter after you've corrected the record."))
+                        {
+                            return false;
+                        }
                     }
                     else
                     {
@@ -114,7 +119,7 @@ namespace PKISharp.WACS.Clients
             }
             else
             {
-                _log.Warning("Verification failed, found value {found} but expected {expected}", value ?? "(null)", expected);
+                _log.Warning("Verification failed, {domain} found value {found} but expected {expected}", $"_acme-challenge.{domain}", value ?? "(null)", expected);
                 return false;
             }
         }


### PR DESCRIPTION
The new CNAME verification worked great for me in the new release, as did the verification of TXT records. I made a slight tweak on my fork to show more information to show the name of the record that should have a CNAME in cases where it is already registered. Here is the before/after.

**Before:**
> [INFO] Existing acme-dns registration for domain www4.mydomain.org found
 [DBUG] Querying name servers for mydomain.org
 [DBUG] Querying IP for name server
 [DBUG] Name server IP 97.74.101.22 identified
 [DBUG] Querying IP for name server
 [DBUG] Name server IP 173.201.69.22 identified
 [WARN] Verification failed, found value (null) but expected fbf2bb10-8442-4c78-9d0a-a2a232518c24.auth.mydomain.org

 **After**
> [INFO] Existing acme-dns registration for domain www4.mydomain.org found
 [INFO] Record: _acme-challenge.www4.mydomain.org
 [INFO] CNAME: fbf2bb10-8442-4c78-9d0a-a2a232518c24.auth.mydomain.org
 [DBUG] Querying name servers for mydomain.org
 [DBUG] Querying IP for name server
 [DBUG] Name server IP 173.201.69.22 identified
 [DBUG] Querying IP for name server
 [DBUG] Name server IP 97.74.101.22 identified
 [WARN] Verification failed, _acme-challenge.www4.mydomain.org found value (null) but expected fbf2bb10-8442-4c78-9d0a-a2a232518c24.auth.mydomain.org

I also updated the test cases with the latest TXT values from a recent update.