### PR TITLE
Add workaround for GUID collision in PluginOptionsConverter (#1093)

### DIFF
--- a/src/main/Plugins/Base/JsonConverter.cs
+++ b/src/main/Plugins/Base/JsonConverter.cs
@@ -31,12 +31,17 @@ namespace PKISharp.WACS.Plugins.Base
     {
         private readonly IDictionary<string, Type> _pluginsOptions;
 
-        public PluginOptionsConverter(IEnumerable<Type> plugins)
+        public PluginOptionsConverter(ILogService _log, IEnumerable<Type> plugins)
         {
             _pluginsOptions = new Dictionary<string, Type>();
             foreach (var p in plugins)
             {
-                _pluginsOptions.Add(p.PluginId(), p);
+                string id = p.PluginId();
+                if (_pluginsOptions.ContainsKey(id))
+                {
+                    _log.Warning("Duplicate Plugin GUID ({0}). Using {1} instead of {2}", id, p.FullName, _pluginsOptions[id].FullName);
+                }
+                _pluginsOptions[id] = p;
             }
         }
 

--- a/src/main/Services/RenewalService.cs
+++ b/src/main/Services/RenewalService.cs
@@ -112,11 +112,11 @@ namespace PKISharp.WACS.Services
                     {
                         var result = JsonConvert.DeserializeObject<Renewal>(
                             File.ReadAllText(rj.FullName),
-                            new PluginOptionsConverter<TargetPluginOptions>(_plugin.PluginOptionTypes<TargetPluginOptions>()),
-                            new PluginOptionsConverter<CsrPluginOptions>(_plugin.PluginOptionTypes<CsrPluginOptions>()),
-                            new PluginOptionsConverter<StorePluginOptions>(_plugin.PluginOptionTypes<StorePluginOptions>()),
-                            new PluginOptionsConverter<ValidationPluginOptions>(_plugin.PluginOptionTypes<ValidationPluginOptions>()),
-                            new PluginOptionsConverter<InstallationPluginOptions>(_plugin.PluginOptionTypes<InstallationPluginOptions>()));
+                            new PluginOptionsConverter<TargetPluginOptions>(_log, _plugin.PluginOptionTypes<TargetPluginOptions>()),
+                            new PluginOptionsConverter<CsrPluginOptions>(_log, _plugin.PluginOptionTypes<CsrPluginOptions>()),
+                            new PluginOptionsConverter<StorePluginOptions>(_log, _plugin.PluginOptionTypes<StorePluginOptions>()),
+                            new PluginOptionsConverter<ValidationPluginOptions>(_log, _plugin.PluginOptionTypes<ValidationPluginOptions>()),
+                            new PluginOptionsConverter<InstallationPluginOptions>(_log, _plugin.PluginOptionTypes<InstallationPluginOptions>()));
                         if (result == null)
                         {
                             throw new Exception("result is empty");


### PR DESCRIPTION
This fix will cause the first `PluginOptions` loaded to win (which was the behavior of the code prior to using GUIDs). This likely isn't sustainable but it will at the least highlight the issue with a warning and revert to old behavior until a more robust behavior can be implemented.