### PR TITLE
Fixed extra menu display for non-IIS users

### DIFF
--- a/src/main/MainMenu.cs
+++ b/src/main/MainMenu.cs
@@ -54,12 +54,6 @@ namespace PKISharp.WACS
                 Choice.Create<Action>(() => Import(RunLevel.Interactive), "Import scheduled renewals from WACS/LEWS 1.9.x", "I"),
                 Choice.Create<Action>(() => { }, "Back", "Q", true)
             };
-            // Simple mode not available without IIS installed, because
-            // it defaults to the IIS installer
-            if (!_container.Resolve<IIISClient>().HasWebSites)
-            {
-                options.RemoveAt(0);
-            }
             _input.ChooseFromList("Please choose from the menu", options).Invoke();
         }
 


### PR DESCRIPTION
#1132 Fixes the menu display for the CLI so that the extra menu's first item is not removed when IIS has no websites.