### PR TITLE
Update validation tokens for acme-dns test case

### DIFF
--- a/src/main.test/Tests/DnsValidationTests/When_resolving_name_servers.cs
+++ b/src/main.test/Tests/DnsValidationTests/When_resolving_name_servers.cs
@@ -21,8 +21,8 @@ namespace PKISharp.WACS.UnitTests.Tests.DnsValidationTests
 
 		[TestMethod]
 		[DataRow("_acme-challenge.logs.hourstrackercloud.com", "Tx1e8X4LF-c615tnacJeuKmzkRmScZzsU-MJHxdDMhU")]
-		[DataRow("_acme-challenge.candell.org", "VFQngqEagia0xpVVA80BIkm-moeWbgTyozbzMvu6S4Q")]
-		[DataRow("_acme-challenge.candell.org", "Vsr-Wn0qP11KkBj-R-xBITMQOhOOQbTORl2BXbXfVHs")]
+		[DataRow("_acme-challenge.www2.candell.org", "IpualE-HBtD8bxr60LoyuLw8FxMPOIUgg2XQTR6mSvw")]
+		[DataRow("_acme-challenge.www2.candell.org", "I2F57jex1qSMXprwPy0crWFSUe2n5AowLitxU0q_WKM")]
         [DataRow("_acme-challenge.wouter.tinus.online", "DHrsG3LudqI9S0jvitp25tDofK1Jf58J08s3c5rIY3k")]
         public void Should_recursively_follow_cnames(string challengeUri, string expectedToken)
 		{


### PR DESCRIPTION
Includes the latest tokens for the two-token test case. Also changed domain to one that won't change every couple months.


