### PR TITLE
Add self-hosted DNS Validation plugin

### DIFF
--- a/src/main/Plugins/ValidationPlugins/Dns/DnsValidation.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/DnsValidation.cs
@@ -55,7 +55,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
             }
         }
 
-        protected bool PreValidate()
+        protected bool PreValidate(bool useDefault=false)
         {
             try
             {
@@ -69,6 +69,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
                 else
                 {
                     dnsClient = _dnsClientProvider.GetClient(domainName);
+                    if (useDefault) dnsClient = _dnsClientProvider.DefaultClient;
                 }
                 if (dnsClient.LookupClient.UseRandomNameServer)
                 {

--- a/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/DnsServerAcme/DnsServerAcme.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/DnsServerAcme/DnsServerAcme.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using DNS.Client;
+using PKISharp.WACS.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using DNS.Client.RequestResolver;
+
+namespace DNS.Server.Acme
+{
+    class DnsServerAcme : IDisposable
+    {
+        private AcmeTXTRecs DnsRecords;
+        private DnsServer selfDnsServer;
+        private ILogService _log;
+        public bool reqReceived = false;
+        public DnsServerAcme(ILogService log)
+        {
+            _log = log;
+            //initialization here for DNS Server events and record storage
+            DnsRecords = new AcmeTXTRecs();
+            selfDnsServer = new DnsServer(DnsRecords);
+            selfDnsServer.Responded += (sender, e) =>
+            {
+                reqReceived = true;
+                _log.Information("DNS Server received lookup request from {remote}", e.Remote.Address.ToString());
+                var questions = e.Request.Questions;
+                foreach (var question in questions)
+                {
+                    _log.Debug("DNS Request: " + question.ToString());
+                }
+                var answers = e.Response.AnswerRecords;
+                foreach (var answer in answers)
+                {
+                    _log.Debug("DNS Response: " + answer.ToString());
+                }
+            };
+            selfDnsServer.Listening += (sender, e) => _log.Information("DNS Server listening...");
+            selfDnsServer.Errored += (sender, e) =>
+            {
+                _log.Debug("Errored: {Error}", e.Exception);
+                ResponseException responseError = e.Exception as ResponseException;
+                if (responseError != null) _log.Debug(responseError.Response.ToString());
+            };
+        }
+        //Addrecord adds a TXT record to the DNS Server
+        public void AddRecord(string recordName, string token)
+        {
+            DnsRecords.AddTextResourceRecord(recordName, token);
+        }
+        public async void Listen()
+        {
+            await selfDnsServer.Listen();
+        }
+
+        public void Dispose()
+        {
+            selfDnsServer.Dispose();
+        }
+
+
+        //AcmeTXTRecs implements IRequestResolver, the database of DNS records used by DnsServer.
+        //The standard implementation had two problems for letsencrypt: it didn't handle the mixed-
+        //case requests that letsencrypt performs. And it assumed an attribute value name that prevented matching.
+        //this version only supports TXT records.
+        private class AcmeTXTRecs : IRequestResolver
+        {
+            private static readonly TimeSpan DEFAULT_TTL = new TimeSpan(0);
+
+            private static bool Matches(Domain domain, Domain entry)
+            {
+                string[] labels = entry.ToString().Split('.');
+                string[] patterns = new string[labels.Length];
+
+                for (int i = 0; i < labels.Length; i++)
+                {
+                    string label = labels[i];
+                    patterns[i] = label == "*" ? "(\\w+)" : Regex.Escape(label);
+                }
+
+                Regex re = new Regex("^" + string.Join("\\.", patterns) + "$", RegexOptions.IgnoreCase);
+                return re.IsMatch(domain.ToString());
+            }
+
+            private static void Merge<T>(IList<T> l1, IList<T> l2)
+            {
+                foreach (T obj in l2)
+                {
+                    l1.Add(obj);
+                }
+            }
+
+            private IList<IResourceRecord> entries = new List<IResourceRecord>();
+            private TimeSpan ttl = DEFAULT_TTL;
+
+            public void AddTextResourceRecord(string domain, string token)
+            {
+                entries.Add(new TextResourceRecord(new Domain(domain), CharacterString.FromString($"{token}"), ttl));
+            }
+
+            public Task<IResponse> Resolve(IRequest request)
+            {
+                IResponse response = Response.FromRequest(request);
+
+                foreach (Question question in request.Questions)
+                {
+                    IList<IResourceRecord> answers = Get(question.Name, question.Type);
+
+                    if (answers.Count > 0)
+                    {
+                        Merge(response.AnswerRecords, answers);
+                    }
+                    else
+                    {
+                        response.ResponseCode = ResponseCode.NameError;
+                    }
+                }
+                return Task.FromResult(response);
+            }
+
+            private IList<IResourceRecord> Get(Domain domain, RecordType type)
+            {
+                return entries.Where(e => Matches(domain, e.Name) && e.Type == type).ToList();
+            }
+        }
+    }
+}

--- a/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/SelfDNS.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/SelfDNS.cs
@@ -1,0 +1,42 @@
+﻿using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Services;
+using DNS.Server.Acme;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    class SelfDNS : DnsValidation<SelfDNSOptions, SelfDNS>
+    {
+        private DnsServerAcme selfDnsServer;
+        public SelfDNS(
+            LookupClientProvider dnsClient,
+            ILogService log,
+            SelfDNSOptions options, string
+            identifier) :
+            base(dnsClient, log, options, identifier)
+        {
+        }
+        public override void PrepareChallenge()
+        {
+            //setup for temporary DNS Server
+            selfDnsServer = new DnsServerAcme(_log);
+
+            CreateRecord(_challenge.DnsRecordName, _challenge.DnsRecordValue);
+            selfDnsServer.Listen();
+
+            PreValidate(true);
+        }
+        public override void CreateRecord(string recordName, string token)
+        {
+           selfDnsServer.AddRecord(recordName, token);
+            _log.Information("Validation TXT {token} added to DNS Server {answerUri}", token, recordName);
+        }
+        public override void DeleteRecord(string recordName, string token)
+        {          
+        }
+        public override void CleanUp()
+        {
+            selfDnsServer.Dispose();
+            base.CleanUp();
+        }
+    }
+}

--- a/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/SelfDNSOptions.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/SelfDNSOptions.cs
@@ -1,0 +1,13 @@
+﻿using PKISharp.WACS.Plugins.Base;
+using PKISharp.WACS.Plugins.Base.Options;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    [Plugin("6f75e466-29f3-458b-89ea-71d8cc4af3c9")]
+    class SelfDNSOptions : ValidationPluginOptions<SelfDNS>
+    {
+        public override string Name => "SelfDNS";
+        public override string Description => "Selfhost Temporary DNS Server";
+        public override string ChallengeType { get => Constants.Dns01ChallengeType; }
+    }
+}

--- a/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/SelfDNSOptionsFactory.cs
+++ b/src/main/Plugins/ValidationPlugins/Dns/SelfDNS/SelfDNSOptionsFactory.cs
@@ -1,0 +1,139 @@
+﻿using PKISharp.WACS.DomainObjects;
+using PKISharp.WACS.Plugins.Base.Factories;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Clients.DNS;
+using DNS.Server.Acme;
+using System.Net;
+using System.Linq;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    class SelfDNSOptionsFactory : ValidationPluginOptionsFactory<SelfDNS, SelfDNSOptions>
+    {
+        private readonly LookupClientProvider _dnsClient;
+        private readonly IInputService _input;
+
+        public SelfDNSOptionsFactory(ILogService log, LookupClientProvider dnsClient,
+            IInputService input) : base(log, Constants.Dns01ChallengeType)
+        {
+            _dnsClient = dnsClient;
+            _input = input;
+        }
+
+        public override SelfDNSOptions Aquire(Target target, IArgumentsService arguments, IInputService inputService, RunLevel runLevel)
+        {
+            const string testTXT = "custom TXTrecord";
+
+            //find external IP address
+            IPAddress serverIP = IPAddress.Parse("8.8.8.8");
+            string externalip = "";
+            try
+            {
+                externalip = new WebClient().DownloadString("http://icanhazip.com").Replace("\n", "");
+                serverIP = IPAddress.Parse(externalip);
+            }
+            catch
+            {
+                _log.Error("couldn't get server's external IP address");
+            }
+
+            _log.Information("To set up self-hosted DNS validation, ensure the following three steps:");
+            _log.Information(" 1. You have opened port 53 in your firewall for incoming requests");
+            _log.Information(" 2. You have created a DNS A record that points to this server ({IP})", externalip);
+            _log.Information(" 3. You have created the following records with your domain host's DNS manager:");
+
+            var identifiers = target.Parts.SelectMany(x => x.Identifiers);
+            identifiers = identifiers.Select(x => x.Replace("*.", "").Insert(0,"_acme-challenge.")).Distinct();
+            foreach (var identifier in identifiers)
+            {
+                _log.Information("   NS for {identifier} ", identifier);
+            }
+            _log.Information("Note: Each NS record should point to this server's name (from step 2)");
+
+            using (DnsServerAcme server = new DnsServerAcme(_log))
+            {
+                foreach (var identifier in identifiers)
+                {
+                    //create a test DNS record for each identifier
+                    server.AddRecord(identifier, testTXT);
+                }
+
+                //start by pre-checking to see whether lookup works by starting a server
+                //and then doing a lookup for a test record or just seeing whether the event fires.
+                server.Listen();
+                bool retry = false;
+                do
+                {
+                    try
+                    {
+                        //use the test server as the name server to check the first identifier
+                        //this should work even if the NS record is not yet set up in the DNS zone
+                        _log.Information("Checking that port 53 is open on {IP}...", externalip);
+                        var TXTResponse = _dnsClient.GetClient(serverIP).GetTextRecordValues(identifiers.First()).ToList();
+                        if (TXTResponse.Any() && TXTResponse.First() == testTXT)
+                        {
+                            _log.Information("Port 53 is open and the DNS server is operating correctly");
+                            break;
+                        }
+                    }
+                    catch
+                    {
+                        _log.Error("An error occurred checking port 53");
+                    }
+                    retry = _input.PromptYesNo("The DNS server is not exposed on port 53. Would you like to try again?", false);
+                } while (retry);
+
+                do
+                {
+                    try
+                    {
+                        int failCount = identifiers.Count();
+                        foreach (var identifier in identifiers)
+                        {
+                            server.reqReceived = false;
+                            _log.Information("Checking NS record setup for {identifier}", identifier);
+                            var TXTResponse = _dnsClient.DefaultClient.GetTextRecordValues(identifier);
+                            if (TXTResponse.Contains(testTXT))
+                            {
+                                _log.Information("Successful lookup for {identifier}", identifier);
+                                failCount -= 1;
+                            }
+                            else if (TXTResponse.Any())
+                            {
+                                _log.Warning("TXT record found for {identifier} but it appears to be coming from a different DNS server. Check the NS record", identifier);
+                            }
+                            else if (server.reqReceived)
+                            {
+                                _log.Warning("A DNS request was received but may have the wrong domain name. Check your NS record");
+                            }
+                            else
+                            {
+                                _log.Warning("No request was received by the DNS server");
+                            }
+                        }
+                        if (failCount == 0)
+                        {
+                            _log.Information("Your NS records are working correctly");
+                            break;
+                        }
+                    }
+                    catch
+                    {
+                        _log.Error("An error occurred while checking records");
+                    }
+                    retry = _input.PromptYesNo("Some of your NS entries are not working. Would you like to test the DNS entries again?", false);
+                } while (retry);
+            }
+            return new SelfDNSOptions();            
+        }
+        public override SelfDNSOptions Default(Target target, IArgumentsService arguments)
+        {
+            return new SelfDNSOptions();
+        }
+
+        public override bool CanValidate(Target target)
+        {
+            return true;
+        }
+    }
+}

--- a/src/main/packages.config
+++ b/src/main/packages.config
@@ -4,6 +4,7 @@
   <package id="Autofac" version="4.8.1" targetFramework="net472" />
   <package id="BouncyCastle" version="1.8.4" targetFramework="net472" />
   <package id="Costura.Fody" version="3.3.1" targetFramework="net472" developmentDependency="true" />
+  <package id="DNS" version="5.0.0" targetFramework="net472" />
   <package id="DnsClient" version="1.2.0" targetFramework="net472" />
   <package id="FluentCommandLineParser" version="1.4.3" targetFramework="net472" />
   <package id="Fody" version="3.3.5" targetFramework="net472" developmentDependency="true" />

--- a/src/main/wacs.csproj
+++ b/src/main/wacs.csproj
@@ -107,6 +107,9 @@
     <Reference Include="Costura, Version=3.3.1.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.3.3.1\lib\net40\Costura.dll</HintPath>
     </Reference>
+    <Reference Include="DNS">
+      <HintPath>..\packages\DNS.5.0.0\lib\netstandard2.0\DNS.dll</HintPath>
+    </Reference>
     <Reference Include="DnsClient, Version=1.2.0.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
       <HintPath>..\packages\DnsClient.1.2.0\lib\net471\DnsClient.dll</HintPath>
     </Reference>
@@ -441,6 +444,10 @@
     <Compile Include="Plugins\ValidationPlugins\Dns\Manual\ManualOptionsFactory.cs" />
     <Compile Include="Plugins\ValidationPlugins\Dns\Script\ScriptArguments.cs" />
     <Compile Include="Plugins\ValidationPlugins\Dns\Script\ScriptArgumentsProvider.cs" />
+    <Compile Include="Plugins\ValidationPlugins\Dns\SelfDNS\DnsServerAcme\DnsServerAcme.cs" />
+    <Compile Include="Plugins\ValidationPlugins\Dns\SelfDNS\SelfDNS.cs" />
+    <Compile Include="Plugins\ValidationPlugins\Dns\SelfDNS\SelfDNSOptions.cs" />
+    <Compile Include="Plugins\ValidationPlugins\Dns\SelfDNS\SelfDNSOptionsFactory.cs" />
     <Compile Include="Plugins\ValidationPlugins\Http\FileSystem\FileSystemArguments.cs" />
     <Compile Include="Plugins\ValidationPlugins\Http\FileSystem\FileSystemArgumentsProvider.cs" />
     <Compile Include="Plugins\ValidationPlugins\Http\HttpValidationArguments.cs" />


### PR DESCRIPTION
Adds a self-hosted DNS validation plugin as an option for DNS validation. The plug-in requires three one-time initial steps:

-Open port 53 on the machine that runs win-acme
-Create an A record in your DNS manager that points to the external IP of your win-acme machine
-Create individual NS records for each domain that you will validate. 

For example, if you are trying to validate test.mydomain.com, you would create the following records:
NS: _acme-challenge.test.mydomain.com  ==> acme.mydomain.com
A: acme.mydomain.com ==> external IP of your win-acme machine

[note: you may already have an A record set up for your win-acme machine]

The plug-in will verify that you have correctly opened the DNS server port and set up the correct records during interactive mode of setup, giving you an opportunity to re-test or bypass the tests if problems occur.

During both setup and actual validation, a stripped-down DNS server will run on your machine and will shut down as soon as verification completes.

Given all of the other mechanisms for DNS validation, this one might not be completely necessary. Compared to the acme-dns server option, the self-host option is a lot easier to maintain and setup, and it doesn't require running a full-time server listening on port 53.

