### PR TITLE
email fix blank renewal name

### DIFF
--- a/src/main/Services/NotificationService.cs
+++ b/src/main/Services/NotificationService.cs
@@ -50,7 +50,7 @@ namespace PKISharp.WACS.Services
             if (runLevel.HasFlag(RunLevel.Unattended))
             {
                 _email.Send("Error processing certificate renewal",
-                    $"<p>Renewal for <b>{renewal.FriendlyName}</b> failed with error <b>{errorMessage}</b>, will retry on next run.</p> {NotificationInformation(renewal)}",
+                    $"<p>Renewal for <b>{renewal.LastFriendlyName}</b> failed with error <b>{errorMessage}</b>, will retry on next run.</p> {NotificationInformation(renewal)}",
                     MailPriority.High);
             }
         }


### PR DESCRIPTION
I received an email about a renewal failure that had a blank target name. This fixed the problem.