### PR TITLE
Handle long strings in multiline show

### DIFF
--- a/src/main/Services/InputService.cs
+++ b/src/main/Services/InputService.cs
@@ -130,9 +130,16 @@ namespace PKISharp.WACS.Services
             while (pos < words.Length)
             {
                 var line = "";
-                while (pos < words.Length && line.Length + words[pos].Length + 1 < step)
+                if ( words[pos].Length +1 >= step)
                 {
-                    line += " " + words[pos++];
+                    line = words[pos++];
+                }
+                else
+                {
+                    while (pos < words.Length && line.Length + words[pos].Length + 1 < step)
+                    {
+                        line += " " + words[pos++];
+                    }
                 }
                 if (!Console.IsOutputRedirected)
                 {


### PR DESCRIPTION
The changes in input service for multi-line word wrap doesn't handle the case where a word length is greater than the line length. Word length greater than the line length causes an infinite loop.

FYI, this came up in the case where a protected string was unable to be decrypted and the resulting string length being displayed is longer than 80 characters. Displaying the details for renewal that has such a string causes an infinite display of blank lines.