### PR TITLE
Updates Challenge Authorize to support 'processing' challange status

### DIFF
--- a/src/main/Renew.cs
+++ b/src/main/Renew.cs
@@ -24,6 +24,7 @@ namespace PKISharp.WACS
 
         private const string _authorizationValid = "valid";
         private const string _authorizationPending = "pending";
+        private const string _authorizationProcessing = "processing";
         private const string _authorizationInvalid = "invalid";
 
         private RenewResult Renew(Renewal renewal, RunLevel runLevel)
@@ -371,7 +372,7 @@ namespace PKISharp.WACS
                         // Have to loop to wait for server to stop being pending
                         var tries = 0;
                         var maxTries = 4;
-                        while (challenge.Status == _authorizationPending)
+                        while (challenge.Status == _authorizationPending || challenge.Status == _authorizationProcessing)
                         {
                             _log.Debug("Refreshing authorization");
                             Thread.Sleep(2000); // this has to be here to give ACME server a chance to think


### PR DESCRIPTION
The RFC indicates that challenge statuses can be one of:  “pending”, “processing”, “valid”, and “invalid". Currently the code is only looking for "pending", "valid" or "invalid" statuses though. See spec reference:

- https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#rfc.section.7.1.5
- https://ietf-wg-acme.github.io/acme/draft-ietf-acme-acme.html#identifier-validation-challenges

I know it's a minor thing but my internal custom CA is returning "processing" causing the certificate request to fail with: 

```
 [EROR] Authorization result: processing
 [EROR] Create certificate failed: Authorization failed
```

Maybe I'm missing something, but shouldn't "processing" be an available status for a challenge? The change seems pretty straightforward so I thought I'd just make a quick pull rather than file a bug but I'm happy to do so if you'd prefer!


