### PR TITLE
Make DNS pre-validation a configuration option

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -236,6 +236,12 @@ Default: `true`
 If set to `true`, it will cleanup the folder structure and files it creates 
 under the site for authorization.
 
+### `PrevalidateDns`
+Default: `true`
+
+If set to `true`, it will wait until it can verify that the validation record
+has been created and is available before beginning DNS validation.
+
 ### `DnsServers`
 Default: `[ "8.8.8.8", "1.1.1.1", "8.8.4.4" ]`
 

--- a/src/main.lib/Plugins/ValidationPlugins/Dns/Acme/Acme.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Dns/Acme/Acme.cs
@@ -7,7 +7,6 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
 {
     internal class Acme : DnsValidation<Acme>
     {
-        private readonly ISettingsService _settings;
         private readonly IInputService _input;
         private readonly ProxyService _proxy;
         private readonly AcmeOptions _options;
@@ -21,11 +20,10 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             ProxyService proxy,
             AcmeOptions options,
             string identifier) :
-            base(dnsClient, log)
+            base(dnsClient, log, settings)
         {
             _options = options;
             _identifier = identifier;
-            _settings = settings;
             _input = input;
             _proxy = proxy;
         }

--- a/src/main.lib/Plugins/ValidationPlugins/Dns/DnsValidation.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Dns/DnsValidation.cs
@@ -16,11 +16,16 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
     {
         protected readonly LookupClientProvider _dnsClientProvider;
         protected readonly ILogService _log;
+        protected readonly ISettingsService _settings;
 
-        protected DnsValidation(LookupClientProvider dnsClient, ILogService log)
+        protected DnsValidation(
+            LookupClientProvider dnsClient, 
+            ILogService log,
+            ISettingsService settings)
         {
             _dnsClientProvider = dnsClient;
             _log = log;
+            _settings = settings;
         }
 
         public override async Task PrepareChallenge()
@@ -33,7 +38,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
             var retry = 0;
             var maxRetries = 5;
             var retrySeconds = 30;
-            while (true)
+            while (_settings.Validation.PrevalidateDns)
             {
                 if (await PreValidate(retry))
                 {

--- a/src/main.lib/Plugins/ValidationPlugins/Dns/Manual/Manual.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Dns/Manual/Manual.cs
@@ -10,8 +10,12 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         private readonly string _identifier;
 
         public Manual(
-            LookupClientProvider dnsClient, ILogService log, 
-            IInputService input, string identifier) : base(dnsClient, log)
+            LookupClientProvider dnsClient, 
+            ILogService log, 
+            IInputService input,
+            ISettingsService settings,
+            string identifier) 
+            : base(dnsClient, log, settings)
         {
             // Usually it's a big no-no to rely on user input in validation plugin
             // because this should be able to run unattended. This plugin is for testing

--- a/src/main.lib/Plugins/ValidationPlugins/Dns/Script/Script.cs
+++ b/src/main.lib/Plugins/ValidationPlugins/Dns/Script/Script.cs
@@ -18,8 +18,9 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             ScriptOptions options,
             LookupClientProvider dnsClient,
             ILogService log,
+            ISettingsService settings,
             string identifier) :
-            base(dnsClient, log)
+            base(dnsClient, log, settings)
         {
             _identifier = identifier;
             _options = options;

--- a/src/main.lib/Services/SettingsService.cs
+++ b/src/main.lib/Services/SettingsService.cs
@@ -379,6 +379,12 @@ namespace PKISharp.WACS.Services
             /// </summary>
             public bool CleanupFolders { get; set; }
             /// <summary>
+            /// If set to `true`, it will wait until it can verify that the 
+            /// validation record has been created and is available before 
+            /// beginning DNS validation.
+            /// </summary>
+            public bool PrevalidateDns { get; set; }
+            /// <summary>
             /// A comma seperated list of servers to query during DNS 
             /// prevalidation checks to verify whether or not the validation 
             /// record has been properly created and is visible for the world.

--- a/src/main/settings.json
+++ b/src/main/settings.json
@@ -50,6 +50,7 @@
   },
   "Validation": {
     "CleanupFolders": true,
+    "PrevalidateDns": true,
     "DnsServers": [ "8.8.8.8", "1.1.1.1", "8.8.4.4" ]
   },
   "Store": {

--- a/src/plugin.validation.dns.azure/Azure.cs
+++ b/src/plugin.validation.dns.azure/Azure.cs
@@ -14,7 +14,13 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         private DnsManagementClient _azureDnsClient;
 
         private readonly AzureOptions _options;
-        public Azure(AzureOptions options, LookupClientProvider dnsClient, ILogService log) : base(dnsClient, log) => _options = options;
+        public Azure(
+            AzureOptions options, 
+            LookupClientProvider dnsClient, 
+            ILogService log,
+            ISettingsService settings) 
+            : base(dnsClient, log, settings)
+            => _options = options;
 
         public override async Task CreateRecord(string recordName, string token)
         {

--- a/src/plugin.validation.dns.dreamhost/DreamhostDnsValidation.cs
+++ b/src/plugin.validation.dns.dreamhost/DreamhostDnsValidation.cs
@@ -9,7 +9,13 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
     {
         private readonly DnsManagementClient _client;
 
-        public DreamhostDnsValidation(LookupClientProvider dnsClient, ILogService logService, DreamhostOptions options) : base(dnsClient, logService) => _client = new DnsManagementClient(options.ApiKey.Value, logService);
+        public DreamhostDnsValidation(
+            LookupClientProvider dnsClient, 
+            ILogService logService, 
+            ISettingsService settings,
+            DreamhostOptions options)
+            : base(dnsClient, logService, settings) 
+            => _client = new DnsManagementClient(options.ApiKey.Value, logService);
 
         public override Task CreateRecord(string recordName, string token) => _client.CreateRecord(recordName, RecordType.TXT, token);
 

--- a/src/plugin.validation.dns.route53/Route53.cs
+++ b/src/plugin.validation.dns.route53/Route53.cs
@@ -16,7 +16,12 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
     {
         private readonly IAmazonRoute53 _route53Client;
 
-        public Route53(LookupClientProvider dnsClient, ILogService log, Route53Options options) : base(dnsClient, log)
+        public Route53(
+            LookupClientProvider dnsClient, 
+            ILogService log,
+            ISettingsService settings,
+            Route53Options options)
+            : base(dnsClient, log, settings)
         {
             var region = RegionEndpoint.USEast1;
             _route53Client = !string.IsNullOrWhiteSpace(options.IAMRole)


### PR DESCRIPTION
The PR adds a new configuration option to enable or disable DNS pre-validation. It's enabled by default to maintain the current functionality.

I've run in to an issue where I'm running win-acme on a network that blocks DNS requests to external servers -- only requests to DNS servers on the local network are allowed. When win-acme attempts to pre-validate DNS changes, it first queries the configured DNS server to get the NS record for the target domain. It then makes a request to the nameserver for the target domain to pre-validate. This request was failing on the locked-down network.

I've added a new `PrevalidateDns` Boolean option to the settings file, defaulting it to `True`. When enabled, the app functions as before. When disabled, the app skips the pre-validation check.