### PR TITLE
Added support for Managed Service Identity in Azure DNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ FakesAssemblies/
 /build/temp
 /build/artifacts
 /src/main/Properties/launchSettings.json
+
+# Rider
+.idea/

--- a/src/plugin.validation.dns.azure/AzureArguments.cs
+++ b/src/plugin.validation.dns.azure/AzureArguments.cs
@@ -2,6 +2,7 @@
 {
     public class AzureArguments
     {
+        public bool AzureUseMsi { get; set; }
         public string AzureTenantId { get; set; }
         public string AzureClientId { get; set; }
         public string AzureSecret { get; set; }

--- a/src/plugin.validation.dns.azure/AzureArgumentsProvider.cs
+++ b/src/plugin.validation.dns.azure/AzureArgumentsProvider.cs
@@ -11,15 +11,24 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
 
         public override bool Active(AzureArguments current)
         {
+            if (current.AzureUseMsi)
+            {
+                return !string.IsNullOrEmpty(current.AzureSubscriptionId) ||
+                       !string.IsNullOrEmpty(current.AzureResourceGroupName);
+            }
+            
             return !string.IsNullOrEmpty(current.AzureTenantId) ||
-                !string.IsNullOrEmpty(current.AzureClientId) ||
-                !string.IsNullOrEmpty(current.AzureSecret) ||
-                !string.IsNullOrEmpty(current.AzureSubscriptionId) ||
-                !string.IsNullOrEmpty(current.AzureResourceGroupName);
+                   !string.IsNullOrEmpty(current.AzureClientId) ||
+                   !string.IsNullOrEmpty(current.AzureSecret) ||
+                   !string.IsNullOrEmpty(current.AzureSubscriptionId) ||
+                   !string.IsNullOrEmpty(current.AzureResourceGroupName);
         }
 
         public override void Configure(FluentCommandLineParser<AzureArguments> parser)
         {
+            parser.Setup(o => o.AzureUseMsi)
+                .As("azureusemsi")
+                .WithDescription("Use Managed Service Identity for authentication.");
             parser.Setup(o => o.AzureTenantId)
                 .As("azuretenantid")
                 .WithDescription("Tenant ID to login into Microsoft Azure.");

--- a/src/plugin.validation.dns.azure/AzureOptions.cs
+++ b/src/plugin.validation.dns.azure/AzureOptions.cs
@@ -12,6 +12,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         public override string Description => "Create verification records in Azure DNS";
         public override string ChallengeType => Constants.Dns01ChallengeType;
 
+        public bool UseMsi { get; set; }
         public string ClientId { get; set; }
         public string ResourceGroupName { get; set; }
 

--- a/src/plugin.validation.dns.azure/AzureOptionsFactory.cs
+++ b/src/plugin.validation.dns.azure/AzureOptionsFactory.cs
@@ -19,27 +19,46 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         public override async Task<AzureOptions> Aquire(Target target, IInputService input, RunLevel runLevel)
         {
             var az = _arguments.GetArguments<AzureArguments>();
-            return new AzureOptions()
+
+            var useMsi = az.AzureUseMsi || await input.PromptYesNo("Do you want to use a managed service identity?", true);
+            var options = new AzureOptions
             {
-                TenantId = await _arguments.TryGetArgument(az.AzureTenantId, input, "Directory/tenant id"),
-                ClientId = await _arguments.TryGetArgument(az.AzureClientId, input, "Application client id"),
-                Secret = new ProtectedString(await _arguments.TryGetArgument(az.AzureSecret, input, "Application client secret", true)),
-                SubscriptionId = await _arguments.TryGetArgument(az.AzureSubscriptionId, input, "DNS subscription id"),
-                ResourceGroupName = await _arguments.TryGetArgument(az.AzureResourceGroupName, input, "DNS resoure group name")
+                UseMsi = useMsi,
             };
+            
+            if (!useMsi)
+            {
+                // These options are only necessary for client id/secret authentication.
+                options.TenantId = await _arguments.TryGetArgument(az.AzureTenantId, input, "Directory/tenant id");
+                options.ClientId = await _arguments.TryGetArgument(az.AzureClientId, input, "Application client id");
+                options.Secret = new ProtectedString(await _arguments.TryGetArgument(az.AzureSecret, input,"Application client secret", true));
+            }
+
+            options.SubscriptionId = await _arguments.TryGetArgument(az.AzureSubscriptionId, input, "DNS subscription id");
+            options.ResourceGroupName = await _arguments.TryGetArgument(az.AzureResourceGroupName, input, "DNS resource group name");
+           
+            return options;
         }
 
         public override Task<AzureOptions> Default(Target target)
         {
             var az = _arguments.GetArguments<AzureArguments>();
-            return Task.FromResult(new AzureOptions()
+            var options = new AzureOptions
             {
-                TenantId = _arguments.TryGetRequiredArgument(nameof(az.AzureTenantId), az.AzureTenantId),
-                ClientId = _arguments.TryGetRequiredArgument(nameof(az.AzureTenantId), az.AzureClientId),
-                Secret = new ProtectedString(_arguments.TryGetRequiredArgument(nameof(az.AzureTenantId), az.AzureSecret)),
-                SubscriptionId = _arguments.TryGetRequiredArgument(nameof(az.AzureTenantId), az.AzureSubscriptionId),
-                ResourceGroupName = _arguments.TryGetRequiredArgument(nameof(az.AzureTenantId), az.AzureResourceGroupName)
-            });
+                UseMsi = az.AzureUseMsi,
+                SubscriptionId = _arguments.TryGetRequiredArgument(nameof(az.AzureSubscriptionId), az.AzureSubscriptionId),
+                ResourceGroupName = _arguments.TryGetRequiredArgument(nameof(az.AzureResourceGroupName), az.AzureResourceGroupName)
+            };
+
+            if (!options.UseMsi)
+            {
+                // These options are only necessary for client id/secret authentication.
+                options.TenantId = _arguments.TryGetRequiredArgument(nameof(az.AzureTenantId), az.AzureTenantId);
+                options.ClientId = _arguments.TryGetRequiredArgument(nameof(az.AzureClientId), az.AzureClientId);
+                options.Secret = new ProtectedString(_arguments.TryGetRequiredArgument(nameof(az.AzureSecret), az.AzureSecret));
+            }
+
+            return Task.FromResult(options);
         }
 
         public override bool CanValidate(Target target) => true;

--- a/src/plugin.validation.dns.azure/wacs.validation.dns.azure.csproj
+++ b/src/plugin.validation.dns.azure/wacs.validation.dns.azure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Added support for Managed Service Identitiy for Azure authentication.
This allows for automatic authentication in the following cases:
* Servers hosted in Azure with MSI
* Users/developers signed in with Azure CLI or Visual Studio

Also contains bugfix with wrong parameter names in CLI validation (AzureOptionsFactory.cs line 24).
This was coded to always return AzureTenantId, no matter what parameter missing.

Comments/improvements/suggestions appreciated.