### PR TITLE
Add a Cloudflare DNS Validation Plugin

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -25,6 +25,7 @@ $BuildFolder = Join-Path -Path $RepoRoot "build"
 & dotnet publish $RepoRoot\src\main\wacs.csproj -c "ReleasePluggable" -r win-x86 /p:PublishSingleFile=true
 
 & dotnet publish $RepoRoot\src\plugin.validation.dns.azure\wacs.validation.dns.azure.csproj -c "Release"
+& dotnet publish $RepoRoot\src\plugin.validation.dns.cloudflare\wacs.validation.dns.cloudflare.csproj -c "Release"
 & dotnet publish $RepoRoot\src\plugin.validation.dns.dreamhost\wacs.validation.dns.dreamhost.csproj -c "Release"
 & dotnet publish $RepoRoot\src\plugin.validation.dns.route53\wacs.validation.dns.route53.csproj -c "Release"
 

--- a/build/create-artifacts.ps1
+++ b/build/create-artifacts.ps1
@@ -98,6 +98,10 @@ PluginRelease route53 plugin.validation.dns.route53 @(
 	"AWSSDK.Route53.dll",
 	"PKISharp.WACS.Plugins.ValidationPlugins.Route53.dll"
 )
+PluginRelease cloudflare plugin.validation.dns.cloudflare @(
+	"FluentCloudflare.dll", 
+	"PKISharp.WACS.Plugins.ValidationPlugins.Cloudflare.dll"
+)
 
 "Created artifacts:"
 dir $Out

--- a/docs/docs.csproj
+++ b/docs/docs.csproj
@@ -59,6 +59,7 @@
     <None Include="reference\plugins\target\index.md" />
     <None Include="reference\plugins\validation\dns\acme-dns.md" />
     <None Include="reference\plugins\validation\dns\azure.md" />
+    <None Include="reference\plugins\validation\dns\cloudflare.md" />
     <None Include="reference\plugins\validation\dns\dreamhost.md" />
     <None Include="reference\plugins\validation\dns\manual.md" />
     <None Include="reference\plugins\validation\dns\index.md" />

--- a/docs/reference/plugins/validation/dns/cloudflare.md
+++ b/docs/reference/plugins/validation/dns/cloudflare.md
@@ -16,8 +16,9 @@ to read and write the DNS records of the zone your domain belongs to.
 1. Navigate here: https://dash.cloudflare.com/profile/api-tokens
 2. Click *Create Token*
 3. Choose a name
-4. Under *Permissions*, select "Zone", "DNS", "Edit"
-5. Under *Zone Resources*, select "Include", "Specific Zone" and the dns zone you want to create certificates for.
+4. Under *Permissions*, select "Zone", "DNS", "Edit"; Click *Add More*, select "Zone", "Zone", "Read"
+5. Under *Zone Resources*, select "Include", "All zones" (or "All zones from an account" and select the relevant account).
+  * Note that restricting access to the single target zone does not work, as we can not get the zone's id by its domain name then. You might be able to exclude other zones specifically. If this is a show stopper for you please open an issue to discuss how to proceed.
 6. Finish creating the token, store it in a safe place or, better, paste it directly into win-acme.
 
 ## Unattended 

--- a/docs/reference/plugins/validation/dns/cloudflare.md
+++ b/docs/reference/plugins/validation/dns/cloudflare.md
@@ -1,0 +1,24 @@
+---
+sidebar: reference
+---
+
+# Cloudflare 
+Create the record in Cloudflare DNS.
+
+{% include plugin-seperate.md %}
+
+## Setup
+This assumes you already have your DNS managed in Cloudflare; if not, you'll need to set that up first. If you are 
+using the Cloudflare DNS option for validation, you'll need to obtain a Cloudflare API Token (not Key) that is allowed
+to read and write the DNS records of the zone your domain belongs to.
+
+### Create an appropriate API Token
+1. Navigate here: https://dash.cloudflare.com/profile/api-tokens
+2. Click *Create Token*
+3. Choose a name
+4. Under *Permissions*, select "Zone", "DNS", "Edit"
+5. Under *Zone Resources*, select "Include", "Specific Zone" and the dns zone you want to create certificates for.
+6. Finish creating the token, store it in a safe place or, better, paste it directly into win-acme.
+
+## Unattended 
+`--validationmode dns-01 --validation cloudflare --cloudflareapitoken ***`

--- a/docs/reference/plugins/validation/dns/cloudflare.md
+++ b/docs/reference/plugins/validation/dns/cloudflare.md
@@ -18,7 +18,7 @@ to read and write the DNS records of the zone your domain belongs to.
 3. Choose a name
 4. Under *Permissions*, select "Zone", "DNS", "Edit"; Click *Add More*, select "Zone", "Zone", "Read"
 5. Under *Zone Resources*, select "Include", "All zones" (or "All zones from an account" and select the relevant account).
-  * Note that restricting access to the single target zone does not work, as we can not get the zone's id by its domain name then. You might be able to exclude other zones specifically. If this is a show stopper for you please open an issue to discuss how to proceed.
+    * Note that restricting access to the single target zone does not work, as we can not get the zone's id by its domain name then. You might be able to exclude other zones specifically. If this is a show stopper for you please open an issue to discuss how to proceed.
 6. Finish creating the token, store it in a safe place or, better, paste it directly into win-acme.
 
 ## Unattended 

--- a/src/plugin.validation.dns.cloudflare/Cloudflare.cs
+++ b/src/plugin.validation.dns.cloudflare/Cloudflare.cs
@@ -1,0 +1,95 @@
+﻿using CF = Cloudflare;
+using Cloudflare.Abstractions.Builders;
+using Cloudflare.Api.Entities;
+using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Plugins.ValidationPlugins;
+using PKISharp.WACS.Services;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    public class Cloudflare : DnsValidation<Cloudflare>
+    {
+        private readonly CloudflareOptions _options;
+        private readonly HttpClient _hc;
+
+        public Cloudflare(
+            CloudflareOptions options,
+            LookupClientProvider dnsClient,
+            ILogService log,
+            ISettingsService settings)
+            : base(dnsClient, log, settings)
+        {
+            _options = options;
+            _hc = new HttpClient();
+        }
+
+        private IAuthorizedSyntax GetContext()
+        {
+            return CF.Cloudflare.WithToken(_options.ApiToken.Value);
+        }
+
+        private async Task<Zone> GetHostedZone(IAuthorizedSyntax context, string recordName)
+        {
+            var prs = _dnsClientProvider.DomainParser;
+            var domainName = $"{prs.GetDomain(recordName)}.{prs.GetTLD(recordName)}";
+            var zonesResp = await context.Zones.List().WithName(domainName).CallAsync(_hc).ConfigureAwait(false);
+
+            if (!zonesResp.Success)
+            {
+                _log.Error(
+                    "Can't find zone for {domainName} at cloudflare.",
+                    domainName);
+                // maybe throwing would be better
+                // this is how the Azure DNS Validator works
+                return null;
+            }
+
+            return zonesResp.Unpack().First();
+        }
+
+        public override async Task CreateRecord(string recordName, string token)
+        {
+            var ctx = GetContext();
+            var zone = await GetHostedZone(ctx, recordName).ConfigureAwait(false);
+            var dns = ctx.Zone(zone).Dns;
+            (await dns.Create(CF.Api.DnsRecordType.TXT, recordName, token).CallAsync(_hc).ConfigureAwait(false)).EnsureSuccess();
+        }
+
+        private async Task DeleteRecord(string recordName, string token, IAuthorizedSyntax context, Zone zone)
+        {
+            var dns = context.Zone(zone).Dns;
+            var records = (await dns
+                .List()
+                .OfType(CF.Api.DnsRecordType.TXT)
+                .WithName(recordName)
+                .WithContent(token)
+                .Match(CF.Api.MatchType.All)
+                .CallAsync(_hc).ConfigureAwait(false)).Unpack();
+            var record = records.FirstOrDefault();
+            if (record != null)
+            {
+                (await dns.Delete(record.Id).CallAsync(_hc).ConfigureAwait(false)).EnsureSuccess();
+            }
+        }
+
+        public override async Task DeleteRecord(string recordName, string token)
+        {
+            var ctx = GetContext();
+            var zone = await GetHostedZone(ctx, recordName).ConfigureAwait(false);
+            await DeleteRecord(recordName, token, ctx, zone);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _hc.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/plugin.validation.dns.cloudflare/Cloudflare.cs
+++ b/src/plugin.validation.dns.cloudflare/Cloudflare.cs
@@ -43,7 +43,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             if (!zonesResp.Success || (zonesResp.Result?.Count ?? 0) < 1)
             {
                 _log.Error(
-                    "Can't find zone for {domainName} at cloudflare.",
+                    "Zone {domainName} could not be found using the Cloudflare API. Maybe you entered a wrong API Token or domain or the API Token does not allow access to this domain?",
                     domainName);
                 // maybe throwing would be better
                 // this is how the Azure DNS Validator works
@@ -57,6 +57,8 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         {
             var ctx = GetContext();
             var zone = await GetHostedZone(ctx, recordName).ConfigureAwait(false);
+            if (zone == null)
+                throw new InvalidOperationException($"The zone for could not be found using the Cloudflare API, thus creating a DNS validation record is impossible.");
             var dns = ctx.Zone(zone).Dns;
             await dns.Create(DnsRecordType.TXT, recordName, token).CallAsync(_hc).ConfigureAwait(false);
         }

--- a/src/plugin.validation.dns.cloudflare/Cloudflare.cs
+++ b/src/plugin.validation.dns.cloudflare/Cloudflare.cs
@@ -1,4 +1,4 @@
-﻿using FluentCloudflare.Abstractions.Builders;
+using FluentCloudflare.Abstractions.Builders;
 using FluentCloudflare.Api;
 using FluentCloudflare.Api.Entities;
 using FluentCloudflare.Extensions;
@@ -58,7 +58,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             var ctx = GetContext();
             var zone = await GetHostedZone(ctx, recordName).ConfigureAwait(false);
             if (zone == null)
-                throw new InvalidOperationException($"The zone for could not be found using the Cloudflare API, thus creating a DNS validation record is impossible.");
+                throw new InvalidOperationException($"The zone could not be found using the Cloudflare API, thus creating a DNS validation record is impossible.");
             var dns = ctx.Zone(zone).Dns;
             await dns.Create(DnsRecordType.TXT, recordName, token).CallAsync(_hc).ConfigureAwait(false);
         }

--- a/src/plugin.validation.dns.cloudflare/Cloudflare.cs
+++ b/src/plugin.validation.dns.cloudflare/Cloudflare.cs
@@ -40,7 +40,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             var domainName = $"{prs.GetDomain(recordName)}.{prs.GetTLD(recordName)}";
             var zonesResp = await context.Zones.List().WithName(domainName).ParseAsync(_hc).ConfigureAwait(false);
 
-            if (!zonesResp.Success)
+            if (!zonesResp.Success || (zonesResp.Result?.Count ?? 0) < 1)
             {
                 _log.Error(
                     "Can't find zone for {domainName} at cloudflare.",

--- a/src/plugin.validation.dns.cloudflare/CloudflareArguments.cs
+++ b/src/plugin.validation.dns.cloudflare/CloudflareArguments.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    public class CloudflareArguments
+    {
+        public string CloudflareApiToken { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.cloudflare/CloudflareArgumentsProvider.cs
+++ b/src/plugin.validation.dns.cloudflare/CloudflareArgumentsProvider.cs
@@ -14,8 +14,6 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
 
         public override string Condition => "--validationmode dns-01 --validation cloudflare";
 
-        public override bool Active(CloudflareArguments current) => !string.IsNullOrWhiteSpace(current.CloudflareApiToken);
-
         public override void Configure(FluentCommandLineParser<CloudflareArguments> parser)
         {
             parser.Setup(o => o.CloudflareApiToken)

--- a/src/plugin.validation.dns.cloudflare/CloudflareArgumentsProvider.cs
+++ b/src/plugin.validation.dns.cloudflare/CloudflareArgumentsProvider.cs
@@ -1,0 +1,26 @@
+﻿using Fclp;
+using PKISharp.WACS.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins
+{
+    public class CloudflareArgumentsProvider : BaseArgumentsProvider<CloudflareArguments>
+    {
+        public override string Name => "Cloudflare";
+
+        public override string Group => "Validation";
+
+        public override string Condition => "--validationmode dns-01 --validation cloudflare";
+
+        public override bool Active(CloudflareArguments current) => !string.IsNullOrWhiteSpace(current.CloudflareApiToken);
+
+        public override void Configure(FluentCommandLineParser<CloudflareArguments> parser)
+        {
+            parser.Setup(o => o.CloudflareApiToken)
+                .As("cloudflareapitoken")
+                .WithDescription("API Token for Cloudflare.");
+        }
+    }
+}

--- a/src/plugin.validation.dns.cloudflare/CloudflareOptions.cs
+++ b/src/plugin.validation.dns.cloudflare/CloudflareOptions.cs
@@ -1,0 +1,17 @@
+﻿using PKISharp.WACS;
+using PKISharp.WACS.Plugins.Base;
+using PKISharp.WACS.Plugins.Base.Options;
+using PKISharp.WACS.Services.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    [Plugin("73af2c2e-4cf1-4198-a4c8-1129003cfb75")]
+    public class CloudflareOptions : ValidationPluginOptions<Cloudflare>
+    {
+        public override string Name => "Cloudflare";
+        public override string Description => "Create verification records in Cloudflare DNS";
+        public override string ChallengeType => Constants.Dns01ChallengeType;
+
+        public ProtectedString ApiToken { get; set; }
+    }
+}

--- a/src/plugin.validation.dns.cloudflare/CloudflareOptionsFactory.cs
+++ b/src/plugin.validation.dns.cloudflare/CloudflareOptionsFactory.cs
@@ -20,7 +20,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             var arg = _arguments.GetArguments<CloudflareArguments>();
             var opts = new CloudflareOptions
             {
-                ApiToken = new ProtectedString(await _arguments.TryGetArgument(arg.CloudflareApiToken, inputService, "API Token", true))
+                ApiToken = new ProtectedString(await _arguments.TryGetArgument(arg.CloudflareApiToken, inputService, "Cloudflare API Token", true))
             };
             return opts;
         }

--- a/src/plugin.validation.dns.cloudflare/CloudflareOptionsFactory.cs
+++ b/src/plugin.validation.dns.cloudflare/CloudflareOptionsFactory.cs
@@ -1,0 +1,40 @@
+﻿using ACMESharp.Authorizations;
+using PKISharp.WACS.DomainObjects;
+using PKISharp.WACS.Plugins.Base.Factories;
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Services.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
+{
+    public class CloudflareOptionsFactory : ValidationPluginOptionsFactory<Cloudflare, CloudflareOptions>
+    {
+        private readonly IArgumentsService _arguments;
+        public CloudflareOptionsFactory(IArgumentsService arguments) : base(Dns01ChallengeValidationDetails.Dns01ChallengeType) => _arguments = arguments;
+
+        public override async Task<CloudflareOptions> Aquire(Target target, IInputService inputService, RunLevel runLevel)
+        {
+            var arg = _arguments.GetArguments<CloudflareArguments>();
+            var opts = new CloudflareOptions
+            {
+                ApiToken = new ProtectedString(await _arguments.TryGetArgument(arg.CloudflareApiToken, inputService, "API Token", true))
+            };
+            return opts;
+        }
+
+        public override Task<CloudflareOptions> Default(Target target)
+        {
+            var arg = _arguments.GetArguments<CloudflareArguments>();
+            var opts = new CloudflareOptions
+            {
+                ApiToken = new ProtectedString(_arguments.TryGetRequiredArgument(nameof(arg.CloudflareApiToken), arg.CloudflareApiToken))
+            };
+            return Task.FromResult(opts);
+        }
+
+        public override bool CanValidate(Target target) => true;
+    }
+}

--- a/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
+++ b/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>PKISharp.WACS.Plugins.ValidationPlugins</RootNamespace>
+    <AssemblyName>PKISharp.WACS.Plugins.ValidationPlugins.Cloudflare</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentCloudflare" Version="0.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\main.lib\wacs.lib.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
+++ b/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentCloudflare" Version="0.2.0" />
+    <PackageReference Include="FluentCloudflare" Version="0.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
+++ b/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentCloudflare" Version="0.1.5" />
+    <PackageReference Include="FluentCloudflare" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
+++ b/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>PKISharp.WACS.Plugins.ValidationPlugins</RootNamespace>
     <AssemblyName>PKISharp.WACS.Plugins.ValidationPlugins.Cloudflare</AssemblyName>
   </PropertyGroup>
@@ -13,11 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\main.lib\wacs.lib.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />

--- a/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
+++ b/src/plugin.validation.dns.cloudflare/wacs.validation.dns.cloudflare.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentCloudflare" Version="0.1.1" />
+    <PackageReference Include="FluentCloudflare" Version="0.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wacs.sln
+++ b/src/wacs.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{1FD6
 		..\.github\ISSUE_TEMPLATE\question.md = ..\.github\ISSUE_TEMPLATE\question.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "wacs.validation.dns.cloudflare", "plugin.validation.dns.cloudflare\wacs.validation.dns.cloudflare.csproj", "{DB1D4461-5563-425E-8D5E-D57893015D73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,12 @@ Global
 		{4D854441-05CB-4F09-B811-5A6BFC83F873}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4D854441-05CB-4F09-B811-5A6BFC83F873}.ReleasePluggable|Any CPU.ActiveCfg = Release|Any CPU
 		{4D854441-05CB-4F09-B811-5A6BFC83F873}.ReleasePluggable|Any CPU.Build.0 = Release|Any CPU
+		{DB1D4461-5563-425E-8D5E-D57893015D73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB1D4461-5563-425E-8D5E-D57893015D73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB1D4461-5563-425E-8D5E-D57893015D73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB1D4461-5563-425E-8D5E-D57893015D73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB1D4461-5563-425E-8D5E-D57893015D73}.ReleasePluggable|Any CPU.ActiveCfg = Release|Any CPU
+		{DB1D4461-5563-425E-8D5E-D57893015D73}.ReleasePluggable|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I created a plugin for dns-01 validation using Cloudflare. I tried to think of every place that needs to be changed (build scripts, docs, etc) and used many concepts of the existing azure plugin. I hope you think this is in scope for an additional plugin. I'd be happy to implement any changes or improvements to this if you see anything that should be done differently. Due to the simplicity of the CF API what this does seems simpler than what is required for i.e. Azure and the setup process should be quite straight forward for the users.

Thank you for providing and constantly improving win-acme!