### PR TITLE
Fix bug in CleanPath where it wasn't cleaning all invalid chars

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,7 +8,9 @@ assignees: ''
 ---
 
 **Before you post**
-First make sure that your question is not already answered by the [manual](/win-acme/manual/getting-started) or [reference](/win-acme/reference/cli).
+First make sure that your question is not already answered by the documentation. Good starting points are: 
+Manual: https://pkisharp.github.io/win-acme/manual/getting-started 
+Reference: https://pkisharp.github.io/win-acme/reference/cli
 
 **Why**
 What are you trying to achieve and for what reason?

--- a/src/main.lib/Clients/IIS/IISHelper.cs
+++ b/src/main.lib/Clients/IIS/IISHelper.cs
@@ -212,6 +212,7 @@ namespace PKISharp.WACS.Clients.IIS
         {
             return site.Bindings.Select(x => x.Host.ToLower()).
                             Where(x => !string.IsNullOrWhiteSpace(x)).
+                            OrderBy(x => x).
                             Distinct().
                             ToList();
         }

--- a/src/main.lib/Extensions/StringExtensions.cs
+++ b/src/main.lib/Extensions/StringExtensions.cs
@@ -31,7 +31,7 @@ namespace PKISharp.WACS.Extensions
             {
                 return null;
             }
-            return Path.GetInvalidFileNameChars().Aggregate(fileName, (current, c) => fileName.Replace(c.ToString(), string.Empty));
+            return Path.GetInvalidFileNameChars().Aggregate(fileName, (current, c) => current.Replace(c.ToString(), string.Empty));
         }
 
         public static string ReplaceNewLines(this string input) => Regex.Replace(input, @"\r\n?|\n", " ");

--- a/src/main.test/Tests/TargetPluginTests/IISSitesTests.cs
+++ b/src/main.test/Tests/TargetPluginTests/IISSitesTests.cs
@@ -134,8 +134,8 @@ namespace PKISharp.WACS.UnitTests.Tests.TargetPluginTests
             var site = iis.GetWebSite(siteId);
             var options = new IISSitesOptions() { SiteIds = new List<long>() { 1, 2 }, CommonName = "missing.example.com" };
             var target = Target(options);
-            Assert.AreEqual(target.IsValid(log), true);
-            Assert.AreEqual(target.CommonName, site.Bindings.First().Host);
+            Assert.AreEqual(true, target.IsValid(log));
+            Assert.AreEqual(site.Bindings.First().Host, target.CommonName);
         }
 
         [TestMethod]


### PR DESCRIPTION
Bug in CleanPath() introduced in b523616a73ee686f898867710e00e0e9392862a1 where it only cleans the last character in GetInvalidFileNameChars().